### PR TITLE
fix: add checksum to trigger pod recreation if secret changes

### DIFF
--- a/charts/flame-node-hub-api-adapter/templates/hub-adapter-deployment.yaml
+++ b/charts/flame-node-hub-api-adapter/templates/hub-adapter-deployment.yaml
@@ -11,10 +11,11 @@ spec:
   replicas: {{ .Values.replicaCount }}
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
       annotations:
+        checksum/secrets: {{ include (print $.Template.BasePath "/hub-adapter-secret.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- end }}
       labels:
         component: hub-adapter-service
         version: {{ .Chart.AppVersion }}

--- a/charts/flame-node-message-broker/templates/node-message-broker-deployment.yml
+++ b/charts/flame-node-message-broker/templates/node-message-broker-deployment.yml
@@ -18,10 +18,10 @@ spec:
       app.kubernetes.io/version: {{ .Chart.AppVersion }}
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
       annotations:
+        {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- end }}
       labels:
         app.kubernetes.io/name: {{ .Release.Name }}-node-message-broker
         app.kubernetes.io/component: server

--- a/charts/flame-node-pod-orchestration/templates/node-pod-orchestration-deployment.yaml
+++ b/charts/flame-node-pod-orchestration/templates/node-pod-orchestration-deployment.yaml
@@ -11,10 +11,10 @@ spec:
       deployment-id:  {{ .Release.Name }}
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
       annotations:
+        {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- end }}
       labels:
         component: po
         version: {{ .Chart.AppVersion }}

--- a/charts/flame-node-result-service/templates/node-result-deployment.yaml
+++ b/charts/flame-node-result-service/templates/node-result-deployment.yaml
@@ -9,10 +9,10 @@ spec:
       app: {{ .Release.Name }}-node-result
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
       annotations:
+        {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- end }}
       labels:
         app: {{ .Release.Name }}-node-result
         {{- with .Values.podLabels }}

--- a/charts/flame-node-ui/templates/node-ui-deployment.yaml
+++ b/charts/flame-node-ui/templates/node-ui-deployment.yaml
@@ -11,10 +11,11 @@ spec:
   replicas: {{ .Values.replicaCount }}
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
       annotations:
+        checksum/secrets: {{ include (print $.Template.BasePath "/node-ui-secret.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- end }}
       labels:
         component: node-ui-service
         version: {{ .Chart.AppVersion }}


### PR DESCRIPTION
Notably fixes the keycloak client secrets for hub-adapter and node-ui when an upgrade is issued