### PR TITLE
Add existingSecret to relevant services for Hub robot secret

### DIFF
--- a/charts/flame-node-hub-api-adapter/templates/_helpers.tpl
+++ b/charts/flame-node-hub-api-adapter/templates/_helpers.tpl
@@ -24,8 +24,11 @@ Set the API's root path. If ingress is enabled, defaults to "/api" else remains 
 Return the secret containing the hub robot secret
 */}}
 {{- define "adapter.hub.secretName" -}}
+{{- $globalRobotSecretName := .Values.global.hub.auth.existingSecret -}}
 {{- $robotSecretName := .Values.hub.auth.existingSecret -}}
-{{- if $robotSecretName -}}
+{{- if $globalRobotSecretName -}}
+    {{- printf "%s" (tpl $globalRobotSecretName $) -}}
+{{- else if $robotSecretName -}}
     {{- printf "%s" (tpl $robotSecretName $) -}}
 {{- else -}}
     {{- printf "%s-hub-adapter-robot-secret" .Release.Name -}}
@@ -39,7 +42,7 @@ Return hub auth API endpoint
 {{- if .Values.global.hub.endpoints.auth -}}
     {{- .Values.global.hub.endpoints.auth -}}
 {{- else -}}
-    {{- .Values.hub.authAPI -}}
+    {{- .Values.hub.endpoints.auth -}}
 {{- end -}}
 {{- end -}}
 
@@ -50,7 +53,7 @@ Return hub core API endpoint
 {{- if .Values.global.hub.endpoints.core -}}
     {{- .Values.global.hub.endpoints.core -}}
 {{- else -}}
-    {{- .Values.hub.coreAPI -}}
+    {{- .Values.hub.endpoints.core -}}
 {{- end -}}
 {{- end -}}
 

--- a/charts/flame-node-hub-api-adapter/templates/hub-adapter-secret.yaml
+++ b/charts/flame-node-hub-api-adapter/templates/hub-adapter-secret.yaml
@@ -13,7 +13,7 @@ data:
 
 ---
 
-{{- if not .Values.hub.auth.existingSecret }}
+{{- if and (not .Values.hub.auth.existingSecret) (not .Values.global.hub.auth.existingSecret) }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/flame-node-hub-api-adapter/values.yaml
+++ b/charts/flame-node-hub-api-adapter/values.yaml
@@ -11,6 +11,8 @@ global:
       robotUser: ""
       ## @param global.hub.auth.robotSecret Robot secret. Overrides hub.auth.robotSecret if provided
       robotSecret: ""
+      ## @param global.hub.auth.existingSecret Valid robot secret encoded in a k8s secret. Overrides hub.auth.existingSecret if provided
+      existingSecret: ""
   node:
     ingress:
       ## @param global.node.ingress.enabled Toggle whether ingress should be enabled
@@ -71,15 +73,16 @@ node:
 
 ## Hub services and data
 hub:
-  ## @param hub.coreApi Hub core API endpoint
-  coreApi: https://privateaim.net/core
-  ## @param hub.authApi Hub auth API endpoint
-  authApi: https://privateaim.net/auth
+  endpoints:
+    ## @param hub.coreApi Hub core API endpoint
+    core: https://privateaim.net/core
+    ## @param hub.authApi Hub auth API endpoint
+    auth: https://privateaim.net/auth
   ## Credentials used for retrieving a valid robot token from the hub
   auth:
-    existingSecret: ""
     robotUser: ""
     robotSecret: ""
+    existingSecret: ""
 
 # This will set the replicaset count more information can be found here: https://kubernetes.io/docs/concepts/workloads/controllers/replicaset/
 replicaCount: 1

--- a/charts/flame-node-message-broker/templates/_helpers.tpl
+++ b/charts/flame-node-message-broker/templates/_helpers.tpl
@@ -5,7 +5,7 @@ Return hub auth API endpoint
 {{- if .Values.global.hub.endpoints.auth -}}
     {{- .Values.global.hub.endpoints.auth -}}
 {{- else -}}
-    {{- .Values.broker.HUB_AUTH_BASE_URL -}}
+    {{- .Values.hub.endpoints.auth -}}
 {{- end -}}
 {{- end -}}
 
@@ -16,7 +16,7 @@ Return hub core API endpoint
 {{- if .Values.global.hub.endpoints.core -}}
     {{- .Values.global.hub.endpoints.core -}}
 {{- else -}}
-    {{- .Values.broker.HUB_BASE_URL -}}
+    {{- .Values.hub.endpoints.core -}}
 {{- end -}}
 {{- end -}}
 
@@ -27,21 +27,24 @@ Return hub messenger API endpoint
 {{- if .Values.global.hub.endpoints.messenger -}}
     {{- .Values.global.hub.endpoints.messenger -}}
 {{- else -}}
-    {{- .Values.broker.HUB_MESSENGER_BASE_URL -}}
+    {{- .Values.hub.endpoints.messenger -}}
 {{- end -}}
 {{- end -}}
 
-## TODO: does message broker use realmId? If not, remove it from the template
-# {{/*
-# Return hub realmId
-# */}}
-# {{- define "broker.hub.realmId" -}}
-# {{- if .Values.global.hub.realmId -}}
-#     {{- .Values.global.hub.realmId -}}
-# {{- else -}}
-#     {{- .Values.broker.HUB_AUTH_REALM_ID -}}
-# {{- end -}}
-# {{- end -}}
+{{/*
+Return the secret containing the hub robot secret
+*/}}
+{{- define "broker.hub.secretName" -}}
+{{- $globalRobotSecretName := .Values.global.hub.auth.existingSecret -}}
+{{- $robotSecretName := .Values.hub.auth.existingSecret -}}
+{{- if $globalRobotSecretName -}}
+    {{- printf "%s" (tpl $globalRobotSecretName $) -}}
+{{- else if $robotSecretName -}}
+    {{- printf "%s" (tpl $robotSecretName $) -}}
+{{- else -}}
+    {{- printf "%s-node-message-broker-hub-auth" .Release.Name -}}
+{{- end -}}
+{{- end -}}
 
 {{/*
 Return hub robot user ID
@@ -50,7 +53,7 @@ Return hub robot user ID
 {{- if .Values.global.hub.auth.robotUser -}}
     {{- .Values.global.hub.auth.robotUser -}}
 {{- else -}}
-    {{- .Values.broker.HUB_AUTH_ROBOT_ID -}}
+    {{- .Values.hub.auth.robotUser -}}
 {{- end -}}
 {{- end -}}
 
@@ -61,7 +64,7 @@ Return hub robot user secret
 {{- if .Values.global.hub.auth.robotSecret -}}
     {{- .Values.global.hub.auth.robotSecret | b64enc -}}
 {{- else -}}
-    {{- .Values.broker.HUB_AUTH_ROBOT_SECRET | b64enc -}}
+    {{- .Values.hub.auth.robotSecret | b64enc -}}
 {{- end -}}
 {{- end -}}
 

--- a/charts/flame-node-message-broker/templates/node-message-broker-deployment.yml
+++ b/charts/flame-node-message-broker/templates/node-message-broker-deployment.yml
@@ -67,8 +67,8 @@ spec:
             - name: HUB_AUTH_ROBOT_SECRET
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Release.Name }}-node-message-broker-hub-auth
-                  key: robot-secret
+                  name: {{ include "broker.hub.secretName" . }}
+                  key: robotSecret
             # DO NOT USE THIS IN PRODUCTION!!! This is just for internal testing purposes.
             - name: NODE_TLS_REJECT_UNAUTHORIZED
               value: "0"

--- a/charts/flame-node-message-broker/templates/node-message-broker-hub-auth-secret.yml
+++ b/charts/flame-node-message-broker/templates/node-message-broker-hub-auth-secret.yml
@@ -1,6 +1,10 @@
+{{- if and (not .Values.hub.auth.existingSecret) (not .Values.global.hub.auth.existingSecret) }}
 apiVersion: v1
 kind: Secret
 metadata:
   name: {{ .Release.Name }}-node-message-broker-hub-auth
+  namespace: {{ .Release.Namespace }}
+type: Opaque
 data:
-  robot-secret: {{ required "A secret associated with the HUB Auth robot id is required." (include "broker.hub.robotSecret" .) }}
+  robotSecret: {{ required "A robot secret for the Hub is required." (include "broker.hub.robotSecret" .) }}
+{{- end }}

--- a/charts/flame-node-message-broker/values.yaml
+++ b/charts/flame-node-message-broker/values.yaml
@@ -6,22 +6,20 @@ global:
       auth: https://auth.privateaim.dev
       ## @param global.hub.endpoints.core Hub Core API endpoint. Overrides broker.HUB_BASE_URL if provided
       core: https://core.privateaim.dev
+      ## @param global.hub.endpoints.core Hub Core API endpoint. Overrides broker.HUB_BASE_URL if provided
+      messenger: https://messenger.privateaim.dev
     auth:
-      ## TODO: does this need to be set? if not, remove it, otherwise, set it to the correct value
-      ## @param global.hub.auth.realmId Realm ID. Overrides broker.HUB_AUTH_REALM_ID
-      # realmId: ""
       ## @param global.hub.auth.robotUser Robot user ID. Overrides broker.HUB_AUTH_ROBOT_ID if provided
       robotUser: ""
       ## @param global.hub.auth.robotSecret Robot secret. Overrides broker.HUB_AUTH_ROBOT_SECRET if provided
       robotSecret: ""
+      ## @param global.hub.auth.existingSecret Valid robot secret encoded in a k8s secret. Overrides hub.auth.existingSecret if provided
+      existingSecret: ""
 
 common:
   timezone: Europe/Berlin
 broker:
   AUTH_JWKS_URL: ""
-  HUB_BASE_URL: https://api.privateaim.net/
-  HUB_AUTH_BASE_URL: https://auth.privateaim.net/
-  HUB_AUTH_ROBOT_ID: ""
   HUB_AUTH_ROBOT_SECRET: ""
 
 # This will set the replicaset count more information can be found here: https://kubernetes.io/docs/concepts/workloads/controllers/replicaset/
@@ -100,6 +98,22 @@ volumeMounts: []
 nodeSelector: {}
 tolerations: []
 affinity: {}
+
+hub:
+  endpoints:
+    ## @param global.hub.endpoints.auth Hub Auth API endpoint. Overrides broker.HUB_AUTH_BASE_URL if provided
+    auth: https://auth.privateaim.dev
+    ## @param global.hub.endpoints.core Hub Core API endpoint. Overrides broker.HUB_BASE_URL if provided
+    core: https://core.privateaim.dev
+    ## @param global.hub.endpoints.core Hub Core API endpoint. Overrides broker.HUB_BASE_URL if provided
+    messenger: https://messenger.privateaim.dev
+  auth:
+    ## @param global.hub.auth.robotUser Robot user ID. Overrides broker.HUB_AUTH_ROBOT_ID if provided
+    robotUser: ""
+    ## @param global.hub.auth.robotSecret Robot secret. Overrides broker.HUB_AUTH_ROBOT_SECRET if provided
+    robotSecret: ""
+    ## @param global.hub.auth.existingSecret Valid robot secret encoded in a k8s secret. Overrides hub.auth.existingSecret if provided
+    existingSecret:
 
 db:
   persistence:

--- a/charts/flame-node-pod-orchestration/templates/_helpers.tpl
+++ b/charts/flame-node-pod-orchestration/templates/_helpers.tpl
@@ -56,7 +56,7 @@ Return hub auth API endpoint
 {{- if .Values.global.hub.endpoints.auth -}}
     {{- .Values.global.hub.endpoints.auth -}}
 {{- else -}}
-    {{- .Values.hub.authAPI -}}
+    {{- .Values.hub.endpoints.auth -}}
 {{- end -}}
 {{- end -}}
 
@@ -67,7 +67,7 @@ Return hub core API endpoint
 {{- if .Values.global.hub.endpoints.core -}}
     {{- .Values.global.hub.endpoints.core -}}
 {{- else -}}
-    {{- .Values.hub.coreAPI -}}
+    {{- .Values.hub.endpoints.core -}}
 {{- end -}}
 {{- end -}}
 
@@ -87,9 +87,24 @@ Return hub robot user secret
 */}}
 {{- define "po.hub.robotSecret" -}}
 {{- if .Values.global.hub.auth.robotSecret -}}
-    {{- .Values.global.hub.auth.robotSecret -}}
+    {{- .Values.global.hub.auth.robotSecret | b64enc -}}
 {{- else -}}
-    {{- .Values.hub.auth.robotSecret -}}
+    {{- .Values.hub.auth.robotSecret | b64enc -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the secret containing the hub robot secret
+*/}}
+{{- define "po.hub.secretName" -}}
+{{- $globalRobotSecretName := .Values.global.hub.auth.existingSecret -}}
+{{- $robotSecretName := .Values.hub.auth.existingSecret -}}
+{{- if $globalRobotSecretName -}}
+    {{- printf "%s" (tpl $globalRobotSecretName $) -}}
+{{- else if $robotSecretName -}}
+    {{- printf "%s" (tpl $robotSecretName $) -}}
+{{- else -}}
+    {{- printf "%s-po-robot-secret" .Release.Name -}}
 {{- end -}}
 {{- end -}}
 

--- a/charts/flame-node-pod-orchestration/templates/node-pod-orchestration-deployment.yaml
+++ b/charts/flame-node-pod-orchestration/templates/node-pod-orchestration-deployment.yaml
@@ -93,10 +93,12 @@ spec:
             - name: HUB_URL_CORE
               value: {{ ( include "po.hub.coreApi" .) | default "https://privateaim.net/core" | quote }}
             - name: HUB_ROBOT_USER
-              value:  {{ required "A  robot ID for the Hub is required." ( include "po.hub.robotUser" .) | quote }}
-            # TODO: change this to secrets
+              value:  {{ required "A robot ID for the Hub is required." ( include "po.hub.robotUser" .) | quote }}
             - name: HUB_ROBOT_SECRET
-              value:  {{ required "A  robot secret for the Hub is required." ( include "po.hub.robotSecret" .) | quote }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "po.hub.secretName" . }}
+                  key: robotSecret
             - name: NODE_NAME
               value: {{ .Values.env.NODE_NAME}}
             - name: NODE_PW

--- a/charts/flame-node-pod-orchestration/templates/node-pod-orchestration-deployment.yaml
+++ b/charts/flame-node-pod-orchestration/templates/node-pod-orchestration-deployment.yaml
@@ -12,6 +12,7 @@ spec:
   template:
     metadata:
       annotations:
+        checksum/secrets: {{ include (print $.Template.BasePath "/node-pod-orchestration-secret.yaml") . | sha256sum }}
         {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -89,9 +90,9 @@ spec:
             - name: HARBOR_PW
               value: {{ .Values.env.HARBOR_PW}}
             - name: HUB_URL_AUTH
-              value: {{ ( include "po.hub.authApi" .) | default "https://privateaim.net/core" | quote }}
+              value: {{ ( include "po.hub.authApi" .) | default "https://auth.privateaim.net" | quote }}
             - name: HUB_URL_CORE
-              value: {{ ( include "po.hub.coreApi" .) | default "https://privateaim.net/core" | quote }}
+              value: {{ ( include "po.hub.coreApi" .) | default "https://core.privateaim.net" | quote }}
             - name: HUB_ROBOT_USER
               value:  {{ required "A robot ID for the Hub is required." ( include "po.hub.robotUser" .) | quote }}
             - name: HUB_ROBOT_SECRET

--- a/charts/flame-node-pod-orchestration/templates/node-pod-orchestration-secret.yaml
+++ b/charts/flame-node-pod-orchestration/templates/node-pod-orchestration-secret.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Release.Name }}-po-keycloak-secret
+  namespace: {{ .Release.Namespace }}
+type: Opaque
+data:
+  podOrcClientSecret: {{ include "po.keycloak.clientSecret" . }}
+
+---
+
+{{- if and (not .Values.hub.auth.existingSecret) (not .Values.global.hub.auth.existingSecret) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Release.Name }}-po-robot-secret
+  namespace: {{ .Release.Namespace }}
+type: Opaque
+data:
+  robotSecret: {{ required "A robot secret for the Hub is required." (include "po.hub.robotSecret" .) }}
+{{- end }}

--- a/charts/flame-node-pod-orchestration/templates/node-ui-secret.yaml
+++ b/charts/flame-node-pod-orchestration/templates/node-ui-secret.yaml
@@ -1,8 +1,0 @@
-apiVersion: v1
-kind: Secret
-metadata:
-  name: {{ .Release.Name }}-po-keycloak-secret
-  namespace: {{ .Release.Namespace }}
-type: Opaque
-data:
-  podOrcClientSecret: {{ include "po.keycloak.clientSecret" . }}

--- a/charts/flame-node-pod-orchestration/values.yaml
+++ b/charts/flame-node-pod-orchestration/values.yaml
@@ -1,3 +1,19 @@
+## Global variables
+global:
+  hub:
+    endpoints:
+      ## @param global.hub.endpoints.auth Hub Auth API endpoint. Overrides hub.authApi if provided
+      auth: https://auth.privateaim.dev
+      ## @param global.hub.endpoints.core Hub Core API endpoint. Overrides hub.coreApi if provided
+      core: https://core.privateaim.dev
+    auth:
+      ## @param global.hub.auth.robotUser Robot user ID. Overrides hub.auth.robotUser if provided
+      robotUser: ""
+      ## @param global.hub.auth.robotSecret Robot secret. Overrides hub.auth.robotSecret if provided
+      robotSecret: ""
+      ## @param global.hub.auth.existingSecret Valid robot secret encoded in a k8s secret. Overrides hub.auth.existingSecret if provided
+      existingSecret: ""
+
 api:
   version: 0.1.0
   domain: localhost
@@ -25,15 +41,17 @@ minio:
   secretKey: ""
 
 hub:
-  ## @param hub.coreApi Hub core API endpoint
-  coreApi: https://auth.privateaim.dev
-  ## @param hub.authApi Hub auth API endpoint
-  authApi: https://core.privateaim.dev
+  endpoints:
+    ## @param hub.coreApi Hub core API endpoint
+    core: https://auth.privateaim.dev
+    ## @param hub.authApi Hub auth API endpoint
+    auth: https://core.privateaim.dev
 
   ## Credentials used for retrieving a valid token from the hub using a robot account
   auth:
     robotUser: ""
     robotSecret: ""
+    existingSecret: ""
 
 # This will set the replicaset count more information can be found here: https://kubernetes.io/docs/concepts/workloads/controllers/replicaset/
 replicaCount: 1

--- a/charts/flame-node-result-service/templates/_helpers.tpl
+++ b/charts/flame-node-result-service/templates/_helpers.tpl
@@ -20,7 +20,7 @@ Return hub auth API endpoint
 {{- if .Values.global.hub.endpoints.auth -}}
     {{- .Values.global.hub.endpoints.auth -}}
 {{- else -}}
-    {{- .Values.hub.authURL -}}
+    {{- .Values.hub.endpoints.auth -}}
 {{- end -}}
 {{- end -}}
 
@@ -31,7 +31,7 @@ Return hub core API endpoint
 {{- if .Values.global.hub.endpoints.core -}}
     {{- .Values.global.hub.endpoints.core -}}
 {{- else -}}
-    {{- .Values.hub.coreURL -}}
+    {{- .Values.hub.endpoints.core -}}
 {{- end -}}
 {{- end -}}
 
@@ -42,7 +42,7 @@ Return hub storage API endpoint
 {{- if .Values.global.hub.endpoints.storage -}}
     {{- .Values.global.hub.endpoints.storage -}}
 {{- else -}}
-    {{- .Values.hub.storageURL -}}
+    {{- .Values.hub.endpoints.storage -}}
 {{- end -}}
 {{- end -}}
 
@@ -50,8 +50,11 @@ Return hub storage API endpoint
 Return the secret containing the hub robot secret
 */}}
 {{- define "results.hub.secretName" -}}
+{{- $globalRobotSecretName := .Values.global.hub.auth.existingSecret -}}
 {{- $robotSecretName := .Values.hub.auth.existingSecret -}}
-{{- if $robotSecretName -}}
+{{- if $globalRobotSecretName -}}
+    {{- printf "%s" (tpl $globalRobotSecretName $) -}}
+{{- else if $robotSecretName -}}
     {{- printf "%s" (tpl $robotSecretName $) -}}
 {{- else -}}
     {{- printf "%s-results-robot-secret" .Release.Name -}}

--- a/charts/flame-node-result-service/templates/node-result-deployment.yaml
+++ b/charts/flame-node-result-service/templates/node-result-deployment.yaml
@@ -108,7 +108,7 @@ spec:
       volumes:
         - name: crypto
           secret:
-            secretName: ecdh-private-key-secret
+            secretName: {{ .Release.Name }}-ecdh-private-key-secret
         {{- with .Values.volumes }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/flame-node-result-service/templates/node-result-secret.yaml
+++ b/charts/flame-node-result-service/templates/node-result-secret.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.hub.auth.existingSecret }}
+{{- if and (not .Values.hub.auth.existingSecret) (not .Values.global.hub.auth.existingSecret) }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/flame-node-result-service/values.yaml
+++ b/charts/flame-node-result-service/values.yaml
@@ -13,20 +13,23 @@ global:
       robotUser:
       ## @param global.hub.auth.robotSecret Robot secret. Overrides env.HUB_PASSWORD if provided
       robotSecret:
+      ## @param global.hub.auth.existingSecret Valid robot secret encoded in a k8s secret. Overrides hub.auth.existingSecret if provided
+      existingSecret:
 
 ## Hub services and data
 hub:
-  ## @param hub.coreApi Hub core API endpoint
-  coreURL: https://core.privateaim.dev
-  ## @param hub.authURL Hub auth API endpoint
-  authURL: https://auth.privateaim.dev
-  ## @param hub.storageURL Hub storage API endpoint
-  storageURL: https://storage.privateaim.dev
+  endpoints:
+    ## @param hub.coreApi Hub core API endpoint
+    core: https://core.privateaim.dev
+    ## @param hub.authURL Hub auth API endpoint
+    auth: https://auth.privateaim.dev
+    ## @param hub.storageURL Hub storage API endpoint
+    storage: https://storage.privateaim.dev
   ## Credentials used for retrieving a valid robot token from the hub
   auth:
-    existingSecret:
     robotUser:
     robotSecret:
+    existingSecret:
 
 env:
   MINIO_USE_SSL: false

--- a/charts/flame-node/templates/private-key-secret.yaml
+++ b/charts/flame-node/templates/private-key-secret.yaml
@@ -1,7 +1,11 @@
+{{- $ecdhFilePath := "private_key.yaml" }}
+{{- if not (.Files.Get $ecdhFilePath) }}
+{{- fail (printf "Required file ./%s is missing! Please generate one using the 'Crypto' tab in the Hub for your node" $ecdhFilePath) }}
+{{- end }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: ecdh-private-key-secret
+  name: {{ .Release.Name }}-ecdh-private-key-secret
   labels:
     app: key
 type: Opaque

--- a/charts/flame-node/templates/private-key-secret.yaml
+++ b/charts/flame-node/templates/private-key-secret.yaml
@@ -1,4 +1,4 @@
-{{- $ecdhFilePath := "private_key.yaml" }}
+{{- $ecdhFilePath := "private_key.pem" }}
 {{- if not (.Files.Get $ecdhFilePath) }}
 {{- fail (printf "Required file ./%s is missing! Please generate one using the 'Crypto' tab in the Hub for your node" $ecdhFilePath) }}
 {{- end }}

--- a/charts/flame-node/values.yaml
+++ b/charts/flame-node/values.yaml
@@ -7,8 +7,13 @@ global:
       messenger: https://messenger.privateaim.dev
       storage: https://storage.privateaim.dev
     auth:
-      robotUser:
-      robotSecret:
+      ## @param global.hub.auth.robotUser Robot user ID
+      robotUser: ""
+      ## @param global.hub.auth.robotSecret Robot secret
+      robotSecret: ""
+      ## @param global.hub.auth.existingSecret Valid robot secret encoded in an existing k8s secret. Overrides robotSecret if provided
+      ## The secret must have a key named "robotSecret"
+      existingSecret: ""
   node:
     ingress:
       ## @param global.node.ingress.enabled Toggle whether ingress should be enabled
@@ -52,7 +57,7 @@ kong:
 
   proxy:
     enabled: true
-    type: ClusterIP  
+    type: ClusterIP
     http:
       enabled: true
       servicePort: 80
@@ -112,7 +117,7 @@ flame-node-result-service:
       robotUser:
       robotSecret:
 
-  env:  
+  env:
     MINIO_USE_SSL: false
     MINIO_BUCKET: flame
     OIDC_CERTS_URL:
@@ -154,15 +159,16 @@ flame-node-result-service:
 
     ## List of buckets to be created after minio install
     ##
-    buckets: [
-      {
-        name: flame,
-        policy: none,
-        purge: false,
-        versioning: false,
-        objectlocking: false
-      }
-    ]
+    buckets:
+      [
+        {
+          name: flame,
+          policy: none,
+          purge: false,
+          versioning: false,
+          objectlocking: false,
+        },
+      ]
       #   # Name of the bucket
       # - name: bucket1
       #   # Policy to be set on the
@@ -183,7 +189,6 @@ flame-node-result-service:
       #   # set objectlocking for
       #   # bucket [true|false] NOTE: versioning is enabled by default if you use locking
       #   objectlocking: false
-
 
     ## Set default image, imageTag, and imagePullPolicy. mode is used to indicate the
     image:
@@ -262,11 +267,11 @@ keycloak:
     enabled: true
     nameOverride: keycloak-postgresql
     auth:
-      postgresPassword:   # Not needed since secret is provided
-      username: keycloak  # custom user
-      password: keycloak  # custom user pwd
+      postgresPassword: # Not needed since secret is provided
+      username: keycloak # custom user
+      password: keycloak # custom user pwd
       database: keycloak
-      existingSecret: kc-password-secret  # admin password, requires "password" key in secret
+      existingSecret: kc-password-secret # admin password, requires "password" key in secret
     architecture: standalone
 
   keycloakConfigCli:
@@ -274,7 +279,6 @@ keycloak:
     ## Must be set to true to apply settings below
     enabled: true
     existingConfigmap: flame-default-realm
-
 
 # hub-api-adapter Values
 flame-node-hub-adapter:
@@ -446,7 +450,7 @@ flame-node-ui:
 ## node-data-store deploys dummy blaze (FHIR) and minio (S3) data stores for testing the Flame Node
 flame-node-data-store:
   enabled: true
-  
+
   # blaze values
   blaze:
     service:
@@ -461,16 +465,16 @@ flame-node-data-store:
         TIMEOUT: 2
 
   # minio values
-  minio:    
-      rootUser: admin
-      rootPassword: admin123
+  minio:
+    rootUser: admin
+    rootPassword: admin123
 
-      mode: standalone
-      replicas: 1
-      resources:
-        requests:
-          memory: 1Gi
+    mode: standalone
+    replicas: 1
+    resources:
+      requests:
+        memory: 1Gi
 
-      persistence:
-        enabled: true
-        size: 5Gi    
+    persistence:
+      enabled: true
+      size: 5Gi


### PR DESCRIPTION
A single existing k8s secret can be passed as a global `existingSecret` that encodes the hub robot secret. This is then read by the 4 services that use the hub robot credentials:

- hub-adapter
- po
- results-service
- message-broker

Any service that did not utilize secrets yet for encoding these credentials were updated to do so