### PR TITLE
Fix Respect Data Store Enabled Flag

### DIFF
--- a/charts/flame-node/Chart.yaml
+++ b/charts/flame-node/Chart.yaml
@@ -49,4 +49,4 @@ dependencies:
   - name: flame-node-data-store
     repository: file://../flame-node-data-store
     version: 0.1.0
-    condition: node-data-store.enabled
+    condition: flame-node-data-store.enabled


### PR DESCRIPTION
Respect whether the data store is enabled or
not using its dedicated flag. Without this a
data store would be deployed no matter what
the flag is set to.

Fixes #22 