### PR TITLE
refactor: remove redundant hub adapter ingress annotation

### DIFF
--- a/charts/flame-node-hub-api-adapter/templates/hub-adapter-ingress.yaml
+++ b/charts/flame-node-hub-api-adapter/templates/hub-adapter-ingress.yaml
@@ -4,7 +4,6 @@ kind: Ingress
 metadata:
   name: {{ .Release.Name }}-hub-adapter-ingress
   annotations:
-    nginx.ingress.kubernetes.io/rewrite-target: /$2
     {{- with .Values.ingress.annotations }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
@@ -20,7 +19,7 @@ spec:
     - host: &host {{ regexReplaceAll "^https?://(.*)" (include "adapter.ingress.hostname" .) "${1}" }}
       http:
         paths:
-          - path: {{ (include "adapter.root.path" .) }}(/|$)(.*)
+          - path: {{ (include "adapter.root.path" .) }}
             pathType: {{ .Values.ingress.pathType }}
             backend:
               service:


### PR DESCRIPTION
This PR removes the ingress rewrite annotation for the hub-adapter. It originally depended on nginx being used as the ingress controller, but since we cannot assume every location uses this engine for their RP/controller, the hub-adapter was updated to make full use of the `API_ROOT_PATH` env var so it is no longer dependent on the ingress annotation for routing subpaths