### PR TITLE
Add jwks override

### DIFF
--- a/charts/flame-node-hub-api-adapter/templates/hub-adapter-deployment.yaml
+++ b/charts/flame-node-hub-api-adapter/templates/hub-adapter-deployment.yaml
@@ -53,6 +53,8 @@ spec:
               value: {{ include "adapter.userIdp.endpoint" . }}
             - name: NODE_SVC_OIDC_URL
               value: {{ printf "http://%s-keycloak:80%s/realms/flame" .Release.Name .Values.idp.httpRelativePath }}
+            - name: OVERRIDE_JWKS
+              value: {{ .Values.idp.jwks | quote }}
             - name: RESULTS_SERVICE_URL
               value: {{ include "adapter.results.endpoint" . }}
             - name: PODORC_SERVICE_URL

--- a/charts/flame-node-hub-api-adapter/values.yaml
+++ b/charts/flame-node-hub-api-adapter/values.yaml
@@ -35,7 +35,6 @@ ingress:
   ## @param ingress.hostname Default host for the ingress record (evaluated as template)
   ##
   hostname: ""
-
   annotations: {}
   className: ""
   # Specify a tls secret to enable TLS for the given hostname
@@ -59,6 +58,9 @@ idp:
   ## @param idp.host URL to keycloak service
   ## Will be inferred using the Release.Name if not defined
   host: ""
+  ## @param idp.jwks JWKS URI to override the endpoints fetched from the IDP issuer
+  ## Meant for local testing where either no FQDN provided or using localhost and port-forwarding
+  jwks: ""
   ## @param idp.httpRelativePath Set the path relative to '/' for IDP resources (e.g. /auth)
   httpRelativePath: ""
 

--- a/charts/flame-node-ui/templates/node-ui-deployment.yaml
+++ b/charts/flame-node-ui/templates/node-ui-deployment.yaml
@@ -52,7 +52,7 @@ spec:
               value: {{ include "ui.userIdp.endpoint" . }}
             - name: NUXT_KEYCLOAK_CLIENT_ID
               value: {{ .Values.idp.clientId | default "node-ui" | quote }}
-            {{ if contains "localhost" (include "ui.userIdp.endpoint" .) }}
+            {{ if or (contains "localhost" (include "ui.userIdp.endpoint" .)) .Values.offline }}
             - name: NUXT_K8S_KEYCLOAK_ENDPOINT
               value: {{ include "ui.keycloak.service.endpoint" . }}
             {{ end }}

--- a/charts/flame-node-ui/values.yaml
+++ b/charts/flame-node-ui/values.yaml
@@ -12,6 +12,7 @@ global:
     hostname:
 
 env: production
+## @param offline Forces the UI to use the internal service endpoint for authentication
 offline: false
 
 ## For defining ingress specific metadata

--- a/charts/flame-node-ui/values.yaml
+++ b/charts/flame-node-ui/values.yaml
@@ -12,6 +12,7 @@ global:
     hostname:
 
 env: production
+offline: false
 
 ## For defining ingress specific metadata
 ingress:

--- a/charts/flame-node/values.yaml
+++ b/charts/flame-node/values.yaml
@@ -330,6 +330,9 @@ flame-node-hub-adapter:
     ## @param idp.host URL to keycloak service
     ## Will be inferred using the Release.Name if not defined
     host:
+    ## @param idp.jwks JWKS URI to override the endpoints fetched from the IDP issuer
+    ## Meant for local testing where either no FQDN provided or using localhost and port-forwarding
+    jwks: ""
     ## @param idp.httpRelativePath Set the path relative to '/' for IDP resources (e.g. /auth)
     httpRelativePath: "/keycloak"
 
@@ -419,6 +422,8 @@ flame-node-message-broker:
     HUB_AUTH_ROBOT_SECRET:
 
 flame-node-ui:
+  ## @param offline Forces the UI to use the internal service endpoint for authentication
+  offline: false
   env: production
 
   ## For defining ingress specific metadata


### PR DESCRIPTION
Add additional environment variables for the UI and Hub Adapter (HA) when working in an airgapped or offline environment.

These settings force the UI to use the k8s svc endpoint for keycloak and forces the hub adapter to do the same for fetching OIDC certs.