### PR TITLE
Add offline back to values

### DIFF
--- a/charts/flame-node/templates/_helpers.tpl
+++ b/charts/flame-node/templates/_helpers.tpl
@@ -141,6 +141,23 @@ Return the endpoint for user authentication
 {{- end -}}
 
 {{/*
+Return whether to enable internal routing to Keycloak for the UI
+If offline is true - true, else if external IDP hostname is provided - false, else if ingress disabled or localhost used - true, else false
+*/}}
+{{- define "ui.auth.internal" -}}
+{{- $ingressDisabled := not (or .Values.global.node.ingress.enabled .Values.ingress.enabled) -}}
+{{- if .Values.offline -}}
+    true
+{{- else if .Values.userIdp.hostname -}}
+    false
+{{- else if or (contains "localhost" (include "ui.userIdp.endpoint" .)) $ingressDisabled -}}
+    true
+{{- else -}}
+    false
+{{- end -}}
+{{- end -}}
+
+{{/*
 Return the hub adapter endpoint
 */}}
 {{- define "ui.adapter.endpoint" -}}
@@ -309,7 +326,9 @@ Return the secret key that contains the Keycloak client secret
 Return the JWKS endpoint for user and client authentication which overrides what is fetched by the API.
 */}}
 {{- define "adapter.jwks.endpoint" -}}
-{{- if .Values.hubAdapter.idp.jwks -}}
+{{- if .Values.offline -}}
+    {{- print (include "keycloak.jwks.endpoint" .) -}}
+{{- else if .Values.hubAdapter.idp.jwks -}}
     {{- print .Values.hubAdapter.idp.jwks -}}
 {{- else -}}
     {{- print "" -}}

--- a/charts/flame-node/templates/ui/deployment.yaml
+++ b/charts/flame-node/templates/ui/deployment.yaml
@@ -1,5 +1,4 @@
 {{- $hasCerts := include "tls.hasCerts" . -}}
-{{- $ingressDisabled := not (or .Values.global.node.ingress.enabled .Values.ingress.enabled) -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -63,10 +62,10 @@ spec:
               value: {{ include "ui.userIdp.endpoint" . }}
             - name: NUXT_IDP_CLIENT_ID
               value: {{ .Values.ui.idp.clientId | default "node-ui" | quote }}
-            {{ if and (or (contains "localhost" (include "ui.userIdp.endpoint" .)) $ingressDisabled) (not .Values.userIdp.hostname) }}
+            {{- if (eq (include "ui.auth.internal" .) "true") }}
             - name: NUXT_PUBLIC_INTERNAL_KEYCLOAK_URL
               value: {{ include "keycloak.service.endpoint" . }}
-            {{ end }}
+            {{- end }}
             - name: NUXT_IDP_CLIENT_SECRET
               valueFrom:
                 secretKeyRef:

--- a/charts/flame-node/values.yaml
+++ b/charts/flame-node/values.yaml
@@ -8,6 +8,11 @@ global:
       ## This overrides ingress.hostname and is also supplied to the bundled keycloak helm chart
       hostname:
 
+## @param offline Forces the UI and hub adapter to use the internal service endpoint for authentication
+## this is useful for when you are using a locally resolveable domain i.e. localhost or similar as defined in /etc/hosts
+## Overrides hubAdapter.idp.jwks and enables NUXT_PUBLIC_INTERNAL_KEYCLOAK_URL for the UI
+offline: false
+
 ## @param userIdp The following settings are used to configure a separate IDP for the Node UI other than the default keycloak instance
 userIdp:
   ## @param userIdp.hostname Hostname for a separate IDP to manage users who can access the FLAME Node UI.


### PR DESCRIPTION
Offline was thought to no longer be needed, but it is required for forcing the backend services to use the k8s keycloak URL in certain situations