### PR TITLE
feat(hub): Ingress controller independent ingress resources & merge root and hub sub path ingress

### DIFF
--- a/charts/flame-hub/templates/_helpers.tpl
+++ b/charts/flame-hub/templates/_helpers.tpl
@@ -73,3 +73,21 @@ Create the name of the service account to use
 {{ .Values.auth.secretName }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Validate ingress mode: global path-based ingress and individual service ingresses are mutually exclusive.
+*/}}
+{{- define "flameHub.validateIngressMode" -}}
+{{- $globalIngressEnabled := .Values.global.flameHub.ingress.enabled -}}
+{{- $individualIngressEnabled := or
+    .Values.clientUI.ingress.enabled
+    .Values.serverCore.ingress.enabled
+    .Values.serverMessenger.ingress.enabled
+    .Values.serverStorage.ingress.enabled
+    .Values.serverTelemetry.ingress.enabled
+    .Values.authup.ingress.enabled
+-}}
+{{- if and $globalIngressEnabled $individualIngressEnabled -}}
+{{- fail "Ingress configuration is mutually exclusive: disable global.flameHub.ingress.enabled or disable individual service ingress settings (clientUI, serverCore, serverMessenger, serverStorage, serverTelemetry, authup)." -}}
+{{- end -}}
+{{- end -}}

--- a/charts/flame-hub/templates/_urls.tpl
+++ b/charts/flame-hub/templates/_urls.tpl
@@ -2,17 +2,19 @@
 core publicURL
 */}}
 {{- define "serverCore.publicURL" -}}
-{{- if .Values.serverCore.ingress.hostname }}
+{{- if and .Values.serverCore.ingress.enabled .Values.serverCore.ingress.hostname }}
 {{- if .Values.serverCore.ingress.ssl }}
 https://{{- .Values.serverCore.ingress.hostname }}
 {{- else }}
 http://{{- .Values.serverCore.ingress.hostname }}
 {{- end }}
 {{- else }}
+{{- if and .Values.global.flameHub.ingress.enabled .Values.global.flameHub.ingress.hostname }}
 {{- if .Values.global.flameHub.ingress.ssl }}
 https://{{ .Values.global.flameHub.ingress.hostname }}/core/
 {{- else }}
 http://{{ .Values.global.flameHub.ingress.hostname }}/core/
+{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}
@@ -21,17 +23,19 @@ http://{{ .Values.global.flameHub.ingress.hostname }}/core/
 storage publicURL
 */}}
 {{- define "serverStorage.publicURL" -}}
-{{- if .Values.serverStorage.ingress.hostname }}
+{{- if and .Values.serverStorage.ingress.enabled .Values.serverStorage.ingress.hostname }}
 {{- if .Values.serverStorage.ingress.ssl }}
 https://{{- .Values.serverStorage.ingress.hostname }}
 {{- else }}
 http://{{- .Values.serverStorage.ingress.hostname }}
 {{- end }}
 {{- else }}
+{{- if and .Values.global.flameHub.ingress.enabled .Values.global.flameHub.ingress.hostname }}
 {{- if .Values.global.flameHub.ingress.ssl }}
 https://{{ .Values.global.flameHub.ingress.hostname }}/storage/
 {{- else }}
 http://{{ .Values.global.flameHub.ingress.hostname }}/storage/
+{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}
@@ -40,17 +44,19 @@ http://{{ .Values.global.flameHub.ingress.hostname }}/storage/
 telemetry publicURL
 */}}
 {{- define "serverTelemetry.publicURL" -}}
-{{- if .Values.serverTelemetry.ingress.hostname }}
+{{- if and .Values.serverTelemetry.ingress.enabled .Values.serverTelemetry.ingress.hostname }}
 {{- if .Values.serverTelemetry.ingress.ssl }}
 https://{{- .Values.serverTelemetry.ingress.hostname }}
 {{- else }}
 http://{{- .Values.serverTelemetry.ingress.hostname }}
 {{- end }}
 {{- else }}
+{{- if and .Values.global.flameHub.ingress.enabled .Values.global.flameHub.ingress.hostname }}
 {{- if .Values.global.flameHub.ingress.ssl }}
 https://{{ .Values.global.flameHub.ingress.hostname }}/telemetry/
 {{- else }}
 http://{{ .Values.global.flameHub.ingress.hostname }}/telemetry/
+{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}
@@ -59,17 +65,19 @@ http://{{ .Values.global.flameHub.ingress.hostname }}/telemetry/
 authup publicURL
 */}}
 {{- define "authup.publicURL" -}}
-{{- if .Values.authup.ingress.hostname }}
+{{- if and .Values.authup.ingress.enabled .Values.authup.ingress.hostname }}
 {{- if .Values.authup.ingress.ssl }}
 https://{{- .Values.authup.ingress.hostname }}
 {{- else }}
 http://{{- .Values.authup.ingress.hostname }}
 {{- end }}
 {{- else }}
+{{- if and .Values.global.flameHub.ingress.enabled .Values.global.flameHub.ingress.hostname }}
 {{- if .Values.global.flameHub.ingress.ssl }}
 https://{{ .Values.global.flameHub.ingress.hostname }}/auth/
 {{- else }}
 http://{{ .Values.global.flameHub.ingress.hostname }}/auth/
+{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/flame-hub/templates/client-ui/ingress.yaml
+++ b/charts/flame-hub/templates/client-ui/ingress.yaml
@@ -3,7 +3,16 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
     name: {{ .Release.Name }}-flame-hub-client-ui
+    {{- with .Values.clientUI.ingress.annotations }}
+    annotations:
+        {{- range $key, $value := . }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
+    {{- end }}
 spec:
+    {{- if .Values.clientUI.ingress.className }}
+    ingressClassName: {{ .Values.clientUI.ingress.className }}
+    {{- end }}
     rules:
         - host: {{ .Values.clientUI.ingress.hostname }}
           http:

--- a/charts/flame-hub/templates/harbor/ingress.yaml
+++ b/charts/flame-hub/templates/harbor/ingress.yaml
@@ -1,0 +1,26 @@
+{{/* Harbor ingress must remain separate because it always needs its own hostname. */}}
+{{- if and .Values.harbor.enabled (not .Values.externalHarbor.enabled) .Values.harbor.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+    name: {{ .Release.Name }}-harbor
+    annotations:
+        {{- range $key, $value := .Values.harbor.ingress.annotations }}
+        {{ $key }}: {{ tpl ($value | toString) $ | quote }}
+        {{- end }}
+spec:
+    {{- if .Values.harbor.ingress.className }}
+    ingressClassName: {{ .Values.harbor.ingress.className }}
+    {{- end }}
+    rules:
+        - host: {{ include "harbor.host" . }}
+          http:
+              paths:
+                  - path: /
+                    pathType: "ImplementationSpecific"
+                    backend:
+                        service:
+                            name: {{ .Release.Name }}-harbor
+                            port:
+                                number: 443
+{{- end }}

--- a/charts/flame-hub/templates/ingress.yaml
+++ b/charts/flame-hub/templates/ingress.yaml
@@ -65,31 +65,3 @@ spec:
                             port:
                                 number: 3000
 {{- end }}
-
-{{/* Harbor ingress is independent of the above ingress since Harbor always needs its own hostname */}}
-{{- if and .Values.harbor.enabled (not .Values.externalHarbor.enabled) .Values.harbor.ingress.enabled }}
----
-apiVersion: networking.k8s.io/v1
-kind: Ingress
-metadata:
-    name: {{ .Release.Name }}-harbor
-    annotations:
-        {{- range $key, $value := .Values.harbor.ingress.annotations }}
-        {{ $key }}: {{ tpl ($value | toString) $ | quote }}
-        {{- end }}
-spec:
-    {{- if .Values.harbor.ingress.className }}
-    ingressClassName: {{ .Values.harbor.ingress.className }}
-    {{- end }}
-    rules:
-        - host: {{ include "harbor.host" . }}
-          http:
-              paths:
-                  - path: /
-                    pathType: "ImplementationSpecific"
-                    backend:
-                        service: 
-                            name: {{ .Release.Name }}-harbor
-                            port:
-                                number: 443
-{{- end }}

--- a/charts/flame-hub/templates/ingress.yaml
+++ b/charts/flame-hub/templates/ingress.yaml
@@ -1,3 +1,4 @@
+{{- include "flameHub.validateIngressMode" . -}}
 {{- if .Values.global.flameHub.ingress.enabled -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress

--- a/charts/flame-hub/templates/ingress.yaml
+++ b/charts/flame-hub/templates/ingress.yaml
@@ -4,11 +4,9 @@ kind: Ingress
 metadata:
     name: {{ .Release.Name }}-flame-hub
     annotations:
-        nginx.ingress.kubernetes.io/rewrite-target: /$2
-        nginx.ingress.kubernetes.io/proxy-buffer-size: "16k"
-        nginx.ingress.kubernetes.io/proxy-body-size: "0"
-        nginx.ingress.kubernetes.io/proxy-send-timeout: "300"
-        nginx.ingress.kubernetes.io/proxy-read-timeout: "300"
+        {{- range $key, $value := .Values.global.flameHub.ingress.annotations }}
+        {{ $key }}: {{ tpl ($value | toString) $ | quote }}
+        {{- end }}
 spec:
     {{- if .Values.global.flameHub.ingress.className }}
     ingressClassName: {{ .Values.global.flameHub.ingress.className }}

--- a/charts/flame-hub/templates/ingress.yaml
+++ b/charts/flame-hub/templates/ingress.yaml
@@ -2,7 +2,7 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-    name: {{ .Release.Name }}-flame-hub-sub-paths
+    name: {{ .Release.Name }}-flame-hub
     annotations:
         nginx.ingress.kubernetes.io/rewrite-target: /$2
         nginx.ingress.kubernetes.io/proxy-buffer-size: "16k"
@@ -20,10 +20,10 @@ spec:
                   - path: /grafana(/|$)(.*)
                     pathType: "ImplementationSpecific"
                     backend:
-                      service:
-                        name: {{ .Release.Name }}-grafana
-                        port:
-                          number: 3000
+                        service:
+                            name: {{ .Release.Name }}-grafana
+                            port:
+                                number: 3000
                   - path: /core(/|$)(.*)
                     pathType: "ImplementationSpecific"
                     backend:
@@ -48,10 +48,10 @@ spec:
                   - path: /telemetry(/|$)(.*)
                     pathType: "ImplementationSpecific"
                     backend:
-                      service:
-                        name: {{ .Release.Name }}-flame-hub-server-telemetry
-                        port:
-                          number: 3000
+                        service:
+                            name: {{ .Release.Name }}-flame-hub-server-telemetry
+                            port:
+                                number: 3000
                   - path: /auth(/|$)(.*)
                     pathType: "ImplementationSpecific"
                     backend:
@@ -59,28 +59,13 @@ spec:
                             name: {{ .Release.Name }}-authup-server-core
                             port:
                                 number: 3000
----
-apiVersion: networking.k8s.io/v1
-kind: Ingress
-metadata:
-    name: {{ .Release.Name }}-flame-hub-root-path
-spec:
-    {{- if .Values.global.flameHub.ingress.className }}
-    ingressClassName: {{ .Values.global.flameHub.ingress.className }}
-    {{- end }}
-    rules:
-        - host: {{ .Values.global.flameHub.ingress.hostname }}
-          http:
-              paths:
-                  - path: /
-                    pathType: "Prefix"
+                  - path: /()(.*)
+                    pathType: "ImplementationSpecific"
                     backend:
                         service:
                             name: {{ .Release.Name }}-flame-hub-client-ui
                             port:
                                 number: 3000
-
-
 {{- end }}
 
 {{/* Harbor ingress is independent of the above ingress since Harbor always needs its own hostname */}}

--- a/charts/flame-hub/templates/ingress.yaml
+++ b/charts/flame-hub/templates/ingress.yaml
@@ -10,6 +10,9 @@ metadata:
         nginx.ingress.kubernetes.io/proxy-send-timeout: "300"
         nginx.ingress.kubernetes.io/proxy-read-timeout: "300"
 spec:
+    {{- if .Values.global.flameHub.ingress.className }}
+    ingressClassName: {{ .Values.global.flameHub.ingress.className }}
+    {{- end }}
     rules:
         - host: {{ .Values.global.flameHub.ingress.hostname }}
           http:
@@ -62,6 +65,9 @@ kind: Ingress
 metadata:
     name: {{ .Release.Name }}-flame-hub-root-path
 spec:
+    {{- if .Values.global.flameHub.ingress.className }}
+    ingressClassName: {{ .Values.global.flameHub.ingress.className }}
+    {{- end }}
     rules:
         - host: {{ .Values.global.flameHub.ingress.hostname }}
           http:
@@ -85,12 +91,13 @@ kind: Ingress
 metadata:
     name: {{ .Release.Name }}-harbor
     annotations:
-        nginx.ingress.kubernetes.io/proxy-body-size: "0"
-        nginx.ingress.kubernetes.io/proxy-read-timeout: "900"
-        nginx.ingress.kubernetes.io/proxy-send-timeout: "900"
-        nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
-        nginx.ingress.kubernetes.io/upstream-vhost: "{{ include "harbor.host" . }}"
+        {{- range $key, $value := .Values.harbor.ingress.annotations }}
+        {{ $key }}: {{ tpl ($value | toString) $ | quote }}
+        {{- end }}
 spec:
+    {{- if .Values.harbor.ingress.className }}
+    ingressClassName: {{ .Values.harbor.ingress.className }}
+    {{- end }}
     rules:
         - host: {{ include "harbor.host" . }}
           http:

--- a/charts/flame-hub/templates/server-core/ingress.yaml
+++ b/charts/flame-hub/templates/server-core/ingress.yaml
@@ -3,7 +3,16 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
     name: {{ .Release.Name }}-flame-hub-server-core
+    {{- with .Values.serverCore.ingress.annotations }}
+    annotations:
+        {{- range $key, $value := . }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
+    {{- end }}
 spec:
+    {{- if .Values.serverCore.ingress.className }}
+    ingressClassName: {{ .Values.serverCore.ingress.className }}
+    {{- end }}
     rules:
         - host: {{ .Values.serverCore.ingress.hostname }}
           http:

--- a/charts/flame-hub/templates/server-messenger/ingress.yaml
+++ b/charts/flame-hub/templates/server-messenger/ingress.yaml
@@ -3,7 +3,16 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
     name: {{ .Release.Name }}-flame-hub-server-messenger
+    {{- with .Values.serverMessenger.ingress.annotations }}
+    annotations:
+        {{- range $key, $value := . }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
+    {{- end }}
 spec:
+    {{- if .Values.serverMessenger.ingress.className }}
+    ingressClassName: {{ .Values.serverMessenger.ingress.className }}
+    {{- end }}
     rules:
         - host: {{ .Values.serverMessenger.ingress.hostname }}
           http:

--- a/charts/flame-hub/templates/server-storage/ingress.yaml
+++ b/charts/flame-hub/templates/server-storage/ingress.yaml
@@ -3,10 +3,12 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
     name: {{ .Release.Name }}-flame-hub-server-storage
+    {{- with .Values.serverStorage.ingress.annotations }}
     annotations:
-      nginx.ingress.kubernetes.io/proxy-body-size: "0"
-      nginx.ingress.kubernetes.io/proxy-send-timeout: "300"
-      nginx.ingress.kubernetes.io/proxy-read-timeout: "300"
+        {{- range $key, $value := . }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
+    {{- end }}
 spec:
     rules:
         - host: {{ .Values.serverStorage.ingress.hostname }}

--- a/charts/flame-hub/templates/server-storage/ingress.yaml
+++ b/charts/flame-hub/templates/server-storage/ingress.yaml
@@ -10,6 +10,9 @@ metadata:
         {{- end }}
     {{- end }}
 spec:
+    {{- if .Values.serverStorage.ingress.className }}
+    ingressClassName: {{ .Values.serverStorage.ingress.className }}
+    {{- end }}
     rules:
         - host: {{ .Values.serverStorage.ingress.hostname }}
           http:

--- a/charts/flame-hub/templates/server-telemetry/ingress.yaml
+++ b/charts/flame-hub/templates/server-telemetry/ingress.yaml
@@ -10,6 +10,9 @@ metadata:
     {{- end }}
   {{- end }}
 spec:
+    {{- if .Values.serverTelemetry.ingress.className }}
+    ingressClassName: {{ .Values.serverTelemetry.ingress.className }}
+    {{- end }}
   rules:
     - host: {{ .Values.serverTelemetry.ingress.hostname }}
       http:
@@ -33,6 +36,9 @@ metadata:
         {{- end }}
     {{- end }}
 spec:
+    {{- if .Values.serverTelemetry.ingress.className }}
+    ingressClassName: {{ .Values.serverTelemetry.ingress.className }}
+    {{- end }}
     rules:
         - host: {{ .Values.serverTelemetry.ingress.hostname }}
           http:

--- a/charts/flame-hub/templates/server-telemetry/ingress.yaml
+++ b/charts/flame-hub/templates/server-telemetry/ingress.yaml
@@ -3,8 +3,12 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ .Release.Name }}-flame-hub-server-telemetry-sub-paths
+  {{- with .Values.serverTelemetry.ingress.subPathAnnotations }}
   annotations:
-    nginx.ingress.kubernetes.io/rewrite-target: /$2
+    {{- range $key, $value := . }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  {{- end }}
 spec:
   rules:
     - host: {{ .Values.serverTelemetry.ingress.hostname }}
@@ -22,8 +26,12 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
     name: {{ .Release.Name }}-flame-hub-server-telemetry
+    {{- with .Values.serverTelemetry.ingress.annotations }}
     annotations:
-      nginx.ingress.kubernetes.io/proxy-body-size: "0"
+        {{- range $key, $value := . }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
+    {{- end }}
 spec:
     rules:
         - host: {{ .Values.serverTelemetry.ingress.hostname }}

--- a/charts/flame-hub/values.yaml
+++ b/charts/flame-hub/values.yaml
@@ -6,6 +6,12 @@ global:
             enabled: true
             ssl: false
             hostname: "localhost"
+            className: ""
+            # Default annotations for ingress nginx
+            # Replace or remove if you use a different ingress controller
+            annotations:
+                nginx.ingress.kubernetes.io/rewrite-target: /$2
+                nginx.ingress.kubernetes.io/proxy-buffer-size: "16k"
 
 image:
     registry: ghcr.io
@@ -297,6 +303,15 @@ harbor:
     externalURL: "" # Required by Harbor, e.g. https://harbor.hub.local
     ingress:
         enabled: true # Harbor always needs its own hostname, this is independent of global path-based ingress
+        className: ""
+        # Default annotations for ingress nginx
+        # Replace or remove if you use a different ingress controller
+        annotations:
+            nginx.ingress.kubernetes.io/proxy-body-size: "0"
+            nginx.ingress.kubernetes.io/proxy-read-timeout: "900"
+            nginx.ingress.kubernetes.io/proxy-send-timeout: "900"
+            nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
+            nginx.ingress.kubernetes.io/upstream-vhost: '{{ include "harbor.host" . }}'
     migration:
         enabled: true
     # persistence:

--- a/charts/flame-hub/values.yaml
+++ b/charts/flame-hub/values.yaml
@@ -53,6 +53,12 @@ serverStorage:
         hostname: ""
         path: "/"
         pathType: "Prefix"
+        # Default annotations for ingress nginx (e.g. for large file uploads)
+        # Replace or remove if you use a different ingress controller
+        annotations:
+            nginx.ingress.kubernetes.io/proxy-body-size: "0"
+            nginx.ingress.kubernetes.io/proxy-send-timeout: "300"
+            nginx.ingress.kubernetes.io/proxy-read-timeout: "300"
 
 serverTelemetry:
     ingress:
@@ -61,6 +67,13 @@ serverTelemetry:
         hostname: ""
         path: "/"
         pathType: "Prefix"
+        # Default annotations for ingress nginx
+        # Replace or remove if you use a different ingress controller
+        annotations:
+            nginx.ingress.kubernetes.io/proxy-body-size: "0"
+        # Annotations for the grafana sub-path ingress (rewrite-target)
+        subPathAnnotations:
+            nginx.ingress.kubernetes.io/rewrite-target: /$2
 
 serverCoreWorker:
     enabled: true

--- a/charts/flame-hub/values.yaml
+++ b/charts/flame-hub/values.yaml
@@ -13,8 +13,12 @@ global:
             # Default annotations for ingress nginx
             # Replace or remove if you use a different ingress controller
             annotations:
-                nginx.ingress.kubernetes.io/rewrite-target: /$2
-                nginx.ingress.kubernetes.io/proxy-buffer-size: "16k"
+                # Example annotations for ingress nginx
+                nginx.ingress.kubernetes.io/rewrite-target: /$2 # for path based routing
+                nginx.ingress.kubernetes.io/proxy-buffer-size: "16k" # for large auth token
+                nginx.ingress.kubernetes.io/proxy-body-size: "0" # for large file uploads
+                nginx.ingress.kubernetes.io/proxy-send-timeout: "300"
+                nginx.ingress.kubernetes.io/proxy-read-timeout: "300"
 
 image:
     registry: ghcr.io
@@ -118,6 +122,9 @@ authup:
         enabled: false
         ssl: false
         hostname: ""
+        className: ""
+        annotations:
+            nginx.ingress.kubernetes.io/proxy-buffer-size: "16k" # for large auth token
 
 rabbitmq:
     nameOverride: "rabbitmq"

--- a/charts/flame-hub/values.yaml
+++ b/charts/flame-hub/values.yaml
@@ -2,6 +2,9 @@ global:
     imagePullPolicy: "IfNotPresent"
 
     flameHub:
+        # enable this ingress for path based routing
+        # alternatively you can enable ingress for each Hub service individually (subdomain-based routing)
+        # enabling this ingress will expose all Hub services on the same domain at different paths (e.g. /core/, /messenger/, /storage/, /telemetry/)
         ingress:
             enabled: true
             ssl: false
@@ -22,16 +25,20 @@ image:
 # internal services
 clientUI:
     cookieDomain: ""
+    # service specific ingress configuration. If you use this, you will need a separate domain for each service
     ingress:
         enabled: false
+        ssl: false
         hostname: ""
         path: "/"
         pathType: "Prefix"
+        className: ""
+        annotations: {}
 
 serverCore:
     ingress:
-        ssl: false
         enabled: false
+        ssl: false
         hostname: ""
         path: "/"
         pathType: "Prefix"
@@ -42,8 +49,8 @@ serverCore:
 
 serverMessenger:
     ingress:
-        ssl: false
         enabled: false
+        ssl: false
         hostname: ""
         path: "/"
         pathType: "Prefix"
@@ -52,8 +59,8 @@ serverMessenger:
 
 serverStorage:
     ingress:
-        ssl: false
         enabled: false
+        ssl: false
         hostname: ""
         path: "/"
         pathType: "Prefix"
@@ -66,8 +73,8 @@ serverStorage:
 
 serverTelemetry:
     ingress:
-        ssl: false
         enabled: false
+        ssl: false
         hostname: ""
         path: "/"
         pathType: "Prefix"
@@ -109,8 +116,8 @@ authup:
         clientSecret: "" # Leave empty for auto-generation
     ingress:
         enabled: false
-        hostname: ""
         ssl: false
+        hostname: ""
 
 rabbitmq:
     nameOverride: "rabbitmq"
@@ -316,10 +323,13 @@ harbor:
     adminPassword: "" # Leave empty for auto-generation
     existingSecret: "flame-hub-auth"
     existingSecretAdminPasswordKey: "harbor-admin-password"
-    exposureType: "proxy"
     externalURL: "" # Required by Harbor, e.g. https://harbor.hub.local
     ingress:
-        enabled: true # Harbor always needs its own hostname, this is independent of global path-based ingress
+        enabled: true # Harbor always needs its own hostname/domain, even when global path-based ingress is enabled
+        ssl: false
+        hostname: ""
+        path: "/"
+        pathType: "Prefix"
         className: ""
         # Default annotations for ingress nginx
         # Replace or remove if you use a different ingress controller
@@ -335,6 +345,10 @@ harbor:
     #     persistentVolumeClaim:
     #         registry:
     #             storageClass: "mayastor-replicated"
+    # exposureType controls the way the harbor subchart is exposed. The harbor subchart provides
+    # its own ingress, but we need to use exposureType proxy (nginx) to allow access internally.
+    # Ingress is handled by the ingress section above.
+    exposureType: "proxy"
     nginx:
         behindReverseProxy: true
         tls:

--- a/charts/flame-hub/values.yaml
+++ b/charts/flame-hub/values.yaml
@@ -35,6 +35,8 @@ serverCore:
         hostname: ""
         path: "/"
         pathType: "Prefix"
+        className: ""
+        annotations: {}
     env:
         masterImagesBranch: ""
 
@@ -45,6 +47,8 @@ serverMessenger:
         hostname: ""
         path: "/"
         pathType: "Prefix"
+        className: ""
+        annotations: {}
 
 serverStorage:
     ingress:

--- a/charts/third-party/authup/templates/ingress.yaml
+++ b/charts/third-party/authup/templates/ingress.yaml
@@ -3,7 +3,16 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
     name: {{ .Release.Name }}-authup-server-core
+    {{- with .Values.ingress.annotations }}
+    annotations:
+        {{- range $key, $value := . }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
+    {{- end }}
 spec:
+    {{- if .Values.ingress.className }}
+    ingressClassName: {{ .Values.ingress.className }}
+    {{- end }}
     rules:
         - host: {{ .Values.ingress.hostname }}
           http:

--- a/charts/third-party/authup/values.yaml
+++ b/charts/third-party/authup/values.yaml
@@ -1,5 +1,7 @@
 ingress:
     enabled: false
+    className: ""
+    annotations: {}
     hostname: ""
     path: "/"
     pathType: "Prefix"


### PR DESCRIPTION
#103 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Ingress annotations are now fully configurable via deployment values for Flame Hub, server components (core, messenger, storage, telemetry), and Harbor.
  * Optional ingress class name can be set per component.
  * Flame Hub routing updated to include a catch‑all path to the UI service for better subpath handling.
* **Chores**
  * Replaced hard-coded annotation entries with user-supplied mappings and sensible defaults for common ingress scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->