### PR TITLE
fix(hub): Persist Docker Images and Master Images Repo for Hub Core W…

### DIFF
--- a/charts/flame-hub/templates/server-core-worker/deployment.yaml
+++ b/charts/flame-hub/templates/server-core-worker/deployment.yaml
@@ -6,6 +6,8 @@ metadata:
     app: "{{ .Release.Name }}-flame-hub-server-core-worker"
 spec:
   replicas: 1
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app: "{{ .Release.Name }}-flame-hub-server-core-worker"

--- a/charts/flame-hub/templates/server-core-worker/deployment.yaml
+++ b/charts/flame-hub/templates/server-core-worker/deployment.yaml
@@ -85,10 +85,16 @@ spec:
           volumeMounts:
               -   name: "{{ .Release.Name }}-docker-sidecar-socket"
                   mountPath: /var/run
+              -   name: "{{ .Release.Name }}-flame-hub-server-core-worker"
+                  mountPath: /usr/src/project/packages/server-core-worker/writable
+                  subPath: project
           {{- else }}
           volumeMounts:
               -   mountPath: "/var/run/docker.sock"
                   name: "{{ .Release.Name }}-flame-hub-server-core-worker-docker-volume"
+              -   name: "{{ .Release.Name }}-flame-hub-server-core-worker"
+                  mountPath: /usr/src/project/packages/server-core-worker/writable
+                  subPath: project
           securityContext:
               privileged: true
           {{- end }}
@@ -132,15 +138,17 @@ spec:
           args: ["--mtu", "1350"]
           {{- end }}
           volumeMounts:
-            - name: "{{ .Release.Name }}-docker-sidecar-graph-storage"
+            - name: "{{ .Release.Name }}-flame-hub-server-core-worker"
               mountPath: /var/lib/docker
+              subPath: dind
             - name: "{{ .Release.Name }}-docker-sidecar-socket"
               mountPath: /var/run
         {{- end }}
       volumes:
+          - name: "{{ .Release.Name }}-flame-hub-server-core-worker"
+            persistentVolumeClaim:
+              claimName: "{{ .Release.Name }}-flame-hub-server-core-worker"
           {{- if .Values.serverCoreWorker.useSidecarDinD }}
-          - name: "{{ .Release.Name }}-docker-sidecar-graph-storage"
-            emptyDir: {}
           - name: "{{ .Release.Name }}-docker-sidecar-socket"
             emptyDir: {}
           {{- else }}

--- a/charts/flame-hub/templates/server-core-worker/pvc.yaml
+++ b/charts/flame-hub/templates/server-core-worker/pvc.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
     name: "{{ .Release.Name }}-flame-hub-server-core-worker"
+    labels:
+        app: "{{ .Release.Name }}-flame-hub-server-core-worker"
 spec:
     accessModes:
         - ReadWriteOnce

--- a/charts/flame-hub/templates/server-core-worker/pvc.yaml
+++ b/charts/flame-hub/templates/server-core-worker/pvc.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+    name: "{{ .Release.Name }}-flame-hub-server-core-worker"
+spec:
+    accessModes:
+        - ReadWriteOnce
+    resources:
+        requests:
+            storage: {{ .Values.serverCoreWorker.persistence.size | quote }}
+    {{- if .Values.serverCoreWorker.persistence.storageClass }}
+    storageClassName: {{ .Values.serverCoreWorker.persistence.storageClass | quote }}
+    {{- end }}

--- a/charts/flame-hub/values.yaml
+++ b/charts/flame-hub/values.yaml
@@ -138,6 +138,10 @@ serverCoreWorker:
     enabled: true
     # Use a docker-in-docker sidecar container instead of mounting the docker socket from the host
     useSidecarDinD: true
+    persistence:
+        size: "100Gi"
+        # See /charts/third-party/openebs for details
+        # storageClass: "mayastor-replicated"
 
 # Credentials configuration
 auth:


### PR DESCRIPTION
…orker

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added configurable persistent storage for the server-core-worker so worker data survives restarts and can be sized/assigned a storage class.
  * Ensured the sidecar now uses the same persistent storage.
  * Changed the worker deployment to use a recreate restart strategy to simplify restarts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->