### PR TITLE
Fix keycloak secret sync

### DIFF
--- a/charts/flame-node/templates/_helpers.tpl
+++ b/charts/flame-node/templates/_helpers.tpl
@@ -68,7 +68,7 @@ Return the service route for the internal keycloak instance"
 Return the endpoint for the internal keycloak instance with the (cleaned) relative path e.g. "/keycloak"
 */}}
 {{- define "keycloak.base.endpoint" -}}
-{{- printf "http://%s:80/keycloak" (include "keycloak.svc.route" .) -}}
+{{- printf "http://%s:80%s" (include "keycloak.svc.route" .) .Values.keycloakx.http.relativePath -}}
 {{- end -}}
 
 {{/*
@@ -97,7 +97,7 @@ Return the user IDP hostname
         {{- printf "http://%s" .Values.userIdp.hostname -}}
     {{- end -}}
 {{- else if and $hostname (or .Values.global.node.ingress.enabled .Values.ingress.enabled) (not (contains "localhost" $hostname)) -}}
-    {{- printf "%s/keycloak/realms/flame" $hostname -}}
+    {{- printf "%s%s/realms/flame" $hostname .Values.keycloakx.http.relativePath -}}
 {{- end -}}
 {{- end -}}
 
@@ -144,7 +144,7 @@ Return the endpoint for user authentication
 {{- if (include "userIdp.hostname" .) -}}
     {{- print (include "userIdp.hostname" .) -}}
 {{- else -}}
-    {{- print "http://localhost:8080/keycloak/realms/flame" -}}
+    {{- printf "http://localhost:8080%s/realms/flame" .Values.keycloakx.http.relativePath -}}
 {{- end -}}
 {{- end -}}
 
@@ -248,6 +248,28 @@ Create valid redirect URIs for keycloak i.e. http & https
 {{- define "ui.keycloak.redirectUris" -}}
 {{- $hostnameStripped := regexReplaceAll "^https?://(.*)" (include "node.ingress.hostname" .) "${1}" -}}
 {{- printf "[ \"https://%s/*\", \"http://%s/*\" ]" $hostnameStripped $hostnameStripped -}}
+{{- end -}}
+
+{{/*
+Generate a stable NUXT_AUTH_SECRET for the node-ui, persisted in the keycloak-client-secrets Secret.
+Uses lookup to preserve the value across upgrades.
+*/}}
+{{- define "ui.nuxtAuthSecret" -}}
+{{- $secretName := printf "%s-keycloak-client-secrets" .Release.Name -}}
+{{- $secretKey := "nuxtAuthSecret" -}}
+{{- $secret := (lookup "v1" "Secret" .Release.Namespace $secretName) -}}
+{{- if and $secret (hasKey $secret.data $secretKey) }}
+    {{- index $secret.data $secretKey }}
+{{- else }}
+    {{- if not (index .Release "nuxt_secret") -}}
+        {{-   $_ := set .Release "nuxt_secret" dict -}}
+    {{- end -}}
+    {{- $key := printf "%s_%s" .Release.Name "nuxt_auth_secret" -}}
+    {{- if not (index .Release.nuxt_secret $key) -}}
+        {{-   $_ := set .Release.nuxt_secret $key (randAlphaNum 32) -}}
+    {{- end -}}
+    {{- print (index .Release.nuxt_secret $key | b64enc) -}}
+{{- end }}
 {{- end -}}
 
 {{/*Hub Adapter helpers*/}}

--- a/charts/flame-node/templates/_helpers.tpl
+++ b/charts/flame-node/templates/_helpers.tpl
@@ -250,28 +250,6 @@ Create valid redirect URIs for keycloak i.e. http & https
 {{- printf "[ \"https://%s/*\", \"http://%s/*\" ]" $hostnameStripped $hostnameStripped -}}
 {{- end -}}
 
-{{/*
-Generate a stable NUXT_AUTH_SECRET for the node-ui, persisted in the keycloak-client-secrets Secret.
-Uses lookup to preserve the value across upgrades.
-*/}}
-{{- define "ui.nuxtAuthSecret" -}}
-{{- $secretName := printf "%s-keycloak-client-secrets" .Release.Name -}}
-{{- $secretKey := "nuxtAuthSecret" -}}
-{{- $secret := (lookup "v1" "Secret" .Release.Namespace $secretName) -}}
-{{- if and $secret (hasKey $secret.data $secretKey) }}
-    {{- index $secret.data $secretKey }}
-{{- else }}
-    {{- if not (index .Release "nuxt_secret") -}}
-        {{-   $_ := set .Release "nuxt_secret" dict -}}
-    {{- end -}}
-    {{- $key := printf "%s_%s" .Release.Name "nuxt_auth_secret" -}}
-    {{- if not (index .Release.nuxt_secret $key) -}}
-        {{-   $_ := set .Release.nuxt_secret $key (randAlphaNum 32) -}}
-    {{- end -}}
-    {{- print (index .Release.nuxt_secret $key | b64enc) -}}
-{{- end }}
-{{- end -}}
-
 {{/*Hub Adapter helpers*/}}
 
 {{/*

--- a/charts/flame-node/templates/_helpers.tpl
+++ b/charts/flame-node/templates/_helpers.tpl
@@ -56,6 +56,15 @@ Return the secret containing the hub robot secret
 {{- end -}}
 {{- end -}}
 
+{{- define "keycloak.relativePath.normalized" -}}
+{{- $path := .Values.keycloakx.http.relativePath | default "/" -}}
+{{- if eq $path "/" -}}
+{{- print "" -}}
+{{- else -}}
+{{- printf "/%s" (trimAll "/" $path) -}}
+{{- end -}}
+{{- end -}}
+
 {{/*
 Return the service route for the internal keycloak instance"
 */}}
@@ -68,7 +77,7 @@ Return the service route for the internal keycloak instance"
 Return the endpoint for the internal keycloak instance with the (cleaned) relative path e.g. "/keycloak"
 */}}
 {{- define "keycloak.base.endpoint" -}}
-{{- printf "http://%s:80%s" (include "keycloak.svc.route" .) .Values.keycloakx.http.relativePath -}}
+{{- printf "http://%s:80%s" (include "keycloak.svc.route" .) (include "keycloak.relativePath.normalized" .) -}}
 {{- end -}}
 
 {{/*
@@ -97,7 +106,7 @@ Return the user IDP hostname
         {{- printf "http://%s" .Values.userIdp.hostname -}}
     {{- end -}}
 {{- else if and $hostname (or .Values.global.node.ingress.enabled .Values.ingress.enabled) (not (contains "localhost" $hostname)) -}}
-    {{- printf "%s%s/realms/flame" $hostname .Values.keycloakx.http.relativePath -}}
+    {{- printf "%s%s/realms/flame" $hostname (include "keycloak.relativePath.normalized" .) -}}
 {{- end -}}
 {{- end -}}
 
@@ -144,7 +153,7 @@ Return the endpoint for user authentication
 {{- if (include "userIdp.hostname" .) -}}
     {{- print (include "userIdp.hostname" .) -}}
 {{- else -}}
-    {{- printf "http://localhost:8080%s/realms/flame" .Values.keycloakx.http.relativePath -}}
+    {{- printf "http://localhost:8080%s/realms/flame" (include "keycloak.relativePath.normalized" .) -}}
 {{- end -}}
 {{- end -}}
 

--- a/charts/flame-node/templates/hub-adapter/deployment.yaml
+++ b/charts/flame-node/templates/hub-adapter/deployment.yaml
@@ -50,7 +50,7 @@ spec:
             - sh
             - -c
             - |
-              until curl -sf {{ include "keycloak.svc.route" . }}:9000/keycloak/health/ready; do
+              until curl -sf {{ include "keycloak.svc.route" . }}:9000{{ .Values.keycloakx.http.relativePath }}/health/ready; do
                 echo "Waiting for Keycloak..."
                 sleep 5
               done

--- a/charts/flame-node/templates/hub-adapter/deployment.yaml
+++ b/charts/flame-node/templates/hub-adapter/deployment.yaml
@@ -50,7 +50,7 @@ spec:
             - sh
             - -c
             - |
-              until curl -sf {{ include "keycloak.svc.route" . }}:9000{{ .Values.keycloakx.http.relativePath }}/health/ready; do
+              until curl -sf {{ include "keycloak.svc.route" . }}:9000{{ (include "keycloak.relativePath.normalized" .) }}/health/ready; do
                 echo "Waiting for Keycloak..."
                 sleep 5
               done

--- a/charts/flame-node/templates/keycloak-secret-sync-job.yaml
+++ b/charts/flame-node/templates/keycloak-secret-sync-job.yaml
@@ -1,0 +1,230 @@
+{{- if not .Values.keycloak.secretSync.skip }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Release.Name }}-keycloak-secret-sync
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/part-of: flame-node
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  annotations:
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-weight: "0"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ .Release.Name }}-keycloak-secret-sync
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/part-of: flame-node
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  annotations:
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-weight: "0"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    resourceNames: ["{{ .Release.Name }}-keycloak-client-secrets"]
+    verbs: ["get", "patch"]
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    resourceNames:
+      - "{{ .Release.Name }}-hub-adapter-deployment"
+      - "{{ .Release.Name }}-node-ui-deployment"
+    verbs: ["get", "patch"]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ .Release.Name }}-keycloak-secret-sync
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/part-of: flame-node
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  annotations:
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-weight: "0"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Release.Name }}-keycloak-secret-sync
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role
+  name: {{ .Release.Name }}-keycloak-secret-sync
+  apiGroup: rbac.authorization.k8s.io
+
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ .Release.Name }}-keycloak-secret-sync
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/part-of: flame-node
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  annotations:
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-weight: "10"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 5
+  template:
+    spec:
+      restartPolicy: OnFailure
+      serviceAccountName: {{ .Release.Name }}-keycloak-secret-sync
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+      containers:
+        - name: sync
+          image: curlimages/curl:latest
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          env:
+            - name: KC_HEALTH_URL
+              value: {{ printf "http://%s:9000%s" (include "keycloak.svc.route" .) .Values.keycloakx.http.relativePath }}
+            - name: KC_URL
+              value: {{ include "keycloak.base.endpoint" . }}
+            - name: KC_REALM
+              value: flame
+            - name: KC_ADMIN_USER
+              valueFrom:
+                secretKeyRef:
+                  name: flame-keycloak-credentials-secret
+                  key: KC_BOOTSTRAP_ADMIN_USERNAME
+            - name: KC_ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: flame-keycloak-credentials-secret
+                  key: KC_BOOTSTRAP_ADMIN_PASSWORD
+            - name: NAMESPACE
+              value: {{ .Release.Namespace }}
+            - name: SECRET_NAME
+              value: {{ .Release.Name }}-keycloak-client-secrets
+            - name: RELEASE_NAME
+              value: {{ .Release.Name }}
+          command:
+            - sh
+            - -c
+            - |
+              set -e
+
+              SA_TOKEN=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
+              SA_CA_CERT="/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+              K8S_URL="https://kubernetes.default.svc"
+
+              echo "Waiting for Keycloak to be ready..."
+              until curl -sf "${KC_HEALTH_URL}/health/ready"; do
+                sleep 5
+              done
+
+              echo "Obtaining admin token..."
+              TOKEN_RESP=$(curl -sf \
+                -d "client_id=admin-cli" \
+                -d "username=${KC_ADMIN_USER}" \
+                -d "password=${KC_ADMIN_PASSWORD}" \
+                -d "grant_type=password" \
+                "${KC_URL}/realms/master/protocol/openid-connect/token")
+              TOKEN=$(echo "$TOKEN_RESP" | grep -o '"access_token":"[^"]*"' | head -1 | cut -d'"' -f4)
+              if [ -z "$TOKEN" ]; then
+                echo "Failed to obtain admin token"
+                exit 1
+              fi
+
+              echo "Reading current K8s Secret values..."
+              K8S_SECRET=$(curl -sf \
+                --cacert "${SA_CA_CERT}" \
+                -H "Authorization: Bearer ${SA_TOKEN}" \
+                "${K8S_URL}/api/v1/namespaces/${NAMESPACE}/secrets/${SECRET_NAME}")
+
+              NEEDS_RESTART=0
+
+              # Sync a single client. Args: <clientId> <secretKey>
+              # Reads Keycloak's current secret for the client. If it differs from
+              # what is stored in the K8s Secret, patches the K8s Secret to match.
+              sync_client() {
+                CLIENT_ID="$1"
+                SECRET_KEY="$2"
+
+                echo "Looking up client UUID for: ${CLIENT_ID}..."
+                CLIENTS_RESP=$(curl -sf \
+                  -H "Authorization: Bearer ${TOKEN}" \
+                  "${KC_URL}/admin/realms/${KC_REALM}/clients?clientId=${CLIENT_ID}")
+                CLIENT_UUID=$(echo "$CLIENTS_RESP" | grep -o '"id":"[^"]*"' | head -1 | cut -d'"' -f4)
+                if [ -z "$CLIENT_UUID" ]; then
+                  echo "Client '${CLIENT_ID}' not found in realm, skipping"
+                  return 0
+                fi
+
+                echo "Reading Keycloak secret for: ${CLIENT_ID}..."
+                SECRET_RESP=$(curl -sf \
+                  -H "Authorization: Bearer ${TOKEN}" \
+                  "${KC_URL}/admin/realms/${KC_REALM}/clients/${CLIENT_UUID}/client-secret")
+                KC_SECRET=$(echo "$SECRET_RESP" | grep -o '"value":"[^"]*"' | head -1 | cut -d'"' -f4)
+                if [ -z "$KC_SECRET" ]; then
+                  echo "Could not read Keycloak secret for '${CLIENT_ID}' (secret hashing may be enabled), skipping"
+                  return 0
+                fi
+
+                KC_SECRET_B64=$(printf '%s' "$KC_SECRET" | base64 | tr -d '\n')
+                K8S_SECRET_B64=$(echo "$K8S_SECRET" | grep -o "\"${SECRET_KEY}\":\"[^\"]*\"" | head -1 | cut -d'"' -f4)
+
+                if [ "$KC_SECRET_B64" = "$K8S_SECRET_B64" ]; then
+                  echo "Secret for '${CLIENT_ID}' is in sync."
+                  return 0
+                fi
+
+                echo "Mismatch for '${CLIENT_ID}' — patching K8s Secret to match Keycloak..."
+                HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+                  -X PATCH \
+                  --cacert "${SA_CA_CERT}" \
+                  -H "Authorization: Bearer ${SA_TOKEN}" \
+                  -H "Content-Type: application/merge-patch+json" \
+                  -d "{\"data\":{\"${SECRET_KEY}\":\"${KC_SECRET_B64}\"}}" \
+                  "${K8S_URL}/api/v1/namespaces/${NAMESPACE}/secrets/${SECRET_NAME}")
+                if [ "$HTTP_STATUS" -lt 200 ] || [ "$HTTP_STATUS" -ge 300 ]; then
+                  echo "Failed to patch K8s Secret for '${CLIENT_ID}': HTTP ${HTTP_STATUS}"
+                  exit 1
+                fi
+                echo "Patched K8s Secret for '${CLIENT_ID}'"
+                NEEDS_RESTART=1
+              }
+
+              sync_client "hub-adapter" "hubAdapterClientSecret"
+              sync_client "node-ui" "nodeUiClientSecret"
+              sync_client "service1" "podOrcClientSecret"
+
+              if [ "$NEEDS_RESTART" -eq 1 ]; then
+                echo "Triggering rolling restarts for affected deployments..."
+                RESTART_TIME=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+                RESTART_PATCH="{\"spec\":{\"template\":{\"metadata\":{\"annotations\":{\"kubectl.kubernetes.io/restartedAt\":\"${RESTART_TIME}\"}}}}}"
+                for DEPLOY in "${RELEASE_NAME}-hub-adapter-deployment" "${RELEASE_NAME}-node-ui-deployment"; do
+                  HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+                    -X PATCH \
+                    --cacert "${SA_CA_CERT}" \
+                    -H "Authorization: Bearer ${SA_TOKEN}" \
+                    -H "Content-Type: application/merge-patch+json" \
+                    -d "${RESTART_PATCH}" \
+                    "${K8S_URL}/apis/apps/v1/namespaces/${NAMESPACE}/deployments/${DEPLOY}")
+                  if [ "$HTTP_STATUS" -ge 200 ] && [ "$HTTP_STATUS" -lt 300 ]; then
+                    echo "Rolling restart triggered for ${DEPLOY}"
+                  else
+                    echo "Warning: could not restart ${DEPLOY}: HTTP ${HTTP_STATUS}"
+                  fi
+                done
+                echo "Done. Deployments are restarting with corrected secrets."
+              else
+                echo "All client secrets are in sync. No restarts needed."
+              fi
+{{- end }}

--- a/charts/flame-node/templates/keycloak-secret-sync-job.yaml
+++ b/charts/flame-node/templates/keycloak-secret-sync-job.yaml
@@ -36,6 +36,7 @@ rules:
     resourceNames:
       - "{{ .Release.Name }}-hub-adapter-deployment"
       - "{{ .Release.Name }}-node-ui-deployment"
+      - "{{ .Release.Name }}-po"
     verbs: ["get", "patch"]
 
 ---
@@ -93,7 +94,7 @@ spec:
               drop: ["ALL"]
           env:
             - name: KC_HEALTH_URL
-              value: {{ printf "http://%s:9000%s" (include "keycloak.svc.route" .) .Values.keycloakx.http.relativePath }}
+              value: {{ printf "http://%s:9000%s" (include "keycloak.svc.route" .) (include "keycloak.relativePath.normalized" .) }}
             - name: KC_URL
               value: {{ include "keycloak.base.endpoint" . }}
             - name: KC_REALM
@@ -201,15 +202,15 @@ spec:
                 NEEDS_RESTART=1
               }
 
-              sync_client "hub-adapter" "hubAdapterClientSecret"
-              sync_client "node-ui" "nodeUiClientSecret"
+              sync_client {{ .Values.hubAdapter.idp.clientId | default "hub-adapter" | quote }} "hubAdapterClientSecret"
+              sync_client {{ .Values.ui.idp.clientId | default "node-ui" | quote }} "nodeUiClientSecret"
               sync_client "service1" "podOrcClientSecret"
 
               if [ "$NEEDS_RESTART" -eq 1 ]; then
                 echo "Triggering rolling restarts for affected deployments..."
                 RESTART_TIME=$(date -u +%Y-%m-%dT%H:%M:%SZ)
                 RESTART_PATCH="{\"spec\":{\"template\":{\"metadata\":{\"annotations\":{\"kubectl.kubernetes.io/restartedAt\":\"${RESTART_TIME}\"}}}}}"
-                for DEPLOY in "${RELEASE_NAME}-hub-adapter-deployment" "${RELEASE_NAME}-node-ui-deployment"; do
+                for DEPLOY in "${RELEASE_NAME}-hub-adapter-deployment" "${RELEASE_NAME}-node-ui-deployment" "${RELEASE_NAME}-po"; do
                   HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
                     -X PATCH \
                     --cacert "${SA_CA_CERT}" \

--- a/charts/flame-node/templates/secret.yaml
+++ b/charts/flame-node/templates/secret.yaml
@@ -3,6 +3,8 @@ kind: Secret
 metadata:
   name: {{ .Release.Name }}-keycloak-client-secrets
   namespace: {{ .Release.Namespace }}
+  annotations:
+    helm.sh/resource-policy: keep
 type: Opaque
 data:
   hubAdapterClientSecret: {{ include "adapter.keycloak.clientSecret" . }}

--- a/charts/flame-node/templates/ui/deployment.yaml
+++ b/charts/flame-node/templates/ui/deployment.yaml
@@ -83,7 +83,7 @@ spec:
                   name: {{ include "ui.keycloak.secretName" . }}
                   key: {{ include "ui.keycloak.secretKey" . }}
             - name: NUXT_AUTH_SECRET
-              value: {{ randAlphaNum 32 | b64enc }}
+              value: {{ .Values.ui.nuxtAuthSecret | default (randAlphaNum 32) | b64enc }}
             {{- if $hasCerts }}
             - name: NODE_EXTRA_CA_CERTS
               value: "/mnt/certs/certs.pem"

--- a/charts/flame-node/values.yaml
+++ b/charts/flame-node/values.yaml
@@ -682,6 +682,11 @@ messageBroker:
 ui:
   env: production
 
+  ## @param nuxtAuthSecret Used for encrypting JWTs, if not set, then a rolling restart is issued for Node UI
+  ## deployment with every upgrade
+  ## Can be generated with `openssl rand -base64 32`
+  nuxtAuthSecret: ""
+
   ## Keycloak related information
   idp:
     ## @param idp.debug If true, the clientId and clientSecret will use pre-defined values

--- a/charts/flame-node/values.yaml
+++ b/charts/flame-node/values.yaml
@@ -54,6 +54,13 @@ autostart:
   ## @param autostart.interval How often (in seconds) the Hub Adapter will probe the Hub for new analyses
   interval: 60
 
+keycloak:
+  secretSync:
+    ## @param keycloak.secretSync.skip Set to true to disable the post-install/post-upgrade Job that syncs
+    ## client secrets from Keycloak's database with the K8s Secret via the keycloak Admin API.
+    ## Only disable this if you are managing Keycloak client secrets out-of-band.
+    skip: false
+
 ## For defining ingress specific metadata
 ingress:
   ## @param ingress.enabled Enable ingress record generation for the Node UI


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds an optional post-install/post-upgrade job to sync Keycloak client secrets into a Kubernetes Secret (with restart behavior when secrets change).
* **Improvements**
  * Keycloak HTTP relative path is now normalized and applied across endpoints and readiness checks.
  * UI auth secret can be set via values (previously always generated).
* **Configuration**
  * New toggles to skip secret sync and to provide the UI auth secret; secret retained across upgrades.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->