### PR TITLE
refactor: use oci repository instead of https for hub dependencies

### DIFF
--- a/charts/flame-hub/Chart.yaml
+++ b/charts/flame-hub/Chart.yaml
@@ -17,27 +17,27 @@ appVersion: "0.1.0"
 dependencies:
   - name: common
     version: 2.31.4
-    repository: https://charts.bitnami.com/bitnami
+    repository: oci://registry-1.docker.io/bitnamicharts
 
   - name: postgresql
     version: 18.5.1
-    repository: https://charts.bitnami.com/bitnami
+    repository: oci://registry-1.docker.io/bitnamicharts
 
   - name: redis
     version: 22.0.6
-    repository: https://charts.bitnami.com/bitnami
+    repository: oci://registry-1.docker.io/bitnamicharts
 
   - name: rabbitmq
     version: 16.0.14
-    repository: https://charts.bitnami.com/bitnami
+    repository: oci://registry-1.docker.io/bitnamicharts
 
   - name: minio
     version: 17.0.21
-    repository: https://charts.bitnami.com/bitnami
+    repository: oci://registry-1.docker.io/bitnamicharts
 
   - name: grafana
     version: 12.1.8
-    repository: https://charts.bitnami.com/bitnami
+    repository: oci://registry-1.docker.io/bitnamicharts
 
   - name: victoria-logs-cluster
     version: 0.0.24
@@ -45,12 +45,12 @@ dependencies:
 
   - name: prometheus
     version: 2.1.23
-    repository: https://charts.bitnami.com/bitnami
+    repository: oci://registry-1.docker.io/bitnamicharts
 
   - condition: harbor.enabled
     name: harbor
     version: 27.0.3
-    repository: https://charts.bitnami.com/bitnami
+    repository: oci://registry-1.docker.io/bitnamicharts
 
   - name: authup
     repository: file://../third-party/authup


### PR DESCRIPTION
This is needed for FluxCD
https://github.com/bitnami/charts/issues/30110#issue-2618491943
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Helm chart dependency repository sources to use OCI registry endpoints while maintaining existing dependency versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->