### PR TITLE
fix(hub): load grafana VL plugin through extra env instead of chart value plugins.

### DIFF
--- a/charts/flame-hub/values.yaml
+++ b/charts/flame-hub/values.yaml
@@ -311,8 +311,10 @@ grafana:
     config:
         useGrafanaIniFile: true
         grafanaIniConfigMap: grafana
-    plugins:
-        - https://github.com/VictoriaMetrics/victorialogs-datasource/releases/download/v0.23.2/victoriametrics-logs-datasource-v0.23.2.zip;victoriametrics-logs-datasource
+    grafana:
+        extraEnvVars:
+            - name: GF_PLUGINS_PREINSTALL_SYNC
+              value: "victoriametrics-logs-datasource@0.27.1@https://github.com/VictoriaMetrics/victorialogs-datasource/releases/download/v0.27.1/victoriametrics-logs-datasource-v0.27.1.zip"
     # See /charts/third-party/openebs for details
     # persistence:
     #     storageClass: "mayastor-replicated"

--- a/charts/flame-hub/values.yaml
+++ b/charts/flame-hub/values.yaml
@@ -312,6 +312,8 @@ grafana:
         useGrafanaIniFile: true
         grafanaIniConfigMap: grafana
     grafana:
+        updateStrategy:
+            type: Recreate
         extraEnvVars:
             - name: GF_PLUGINS_PREINSTALL_SYNC
               value: "victoriametrics-logs-datasource@0.27.1@https://github.com/VictoriaMetrics/victorialogs-datasource/releases/download/v0.27.1/victoriametrics-logs-datasource-v0.27.1.zip"

--- a/charts/flame-hub/values_min.yaml
+++ b/charts/flame-hub/values_min.yaml
@@ -14,10 +14,6 @@ authup:
     adminPassword: "" # Leave empty for auto-generation
     # See README.md for more details on how to access auto-generated credentials
 
-grafana:
-  # disable plugins until plugin issues are fixed
-  plugins:
-
 harbor:
   enabled: true
   # Specify a default Harbor admin password for local testing


### PR DESCRIPTION
The chart value "plugins" uses an outdated env var.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Grafana VictoriaMetrics logs datasource plugin to version 0.27.1 with an improved installation method.
  * Modified Grafana update strategy for enhanced deployment handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PrivateAIM/helm/pull/132?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->