### PR TITLE
feat(hub): make replica count configurable for client UI

### DIFF
--- a/charts/flame-hub/templates/client-ui/deployment.yaml
+++ b/charts/flame-hub/templates/client-ui/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: "{{ .Release.Name }}-flame-hub-client-ui"
 spec:
-  replicas: 3
+  replicas: {{ .Values.clientUI.replicaCount }}
   selector:
     matchLabels:
       app: "{{ .Release.Name }}-flame-hub-client-ui"

--- a/charts/flame-hub/values.yaml
+++ b/charts/flame-hub/values.yaml
@@ -61,6 +61,7 @@ image:
 
 # internal services
 clientUI:
+    replicaCount: 3
     publicHttps: false # global.flameHub.publicHttps also enables this
     cookieDomain: ""
     # service specific ingress configuration. If you use this, you will need a separate domain for each service


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced deployment flexibility by making the client UI replica count configurable through chart values instead of a fixed hardcoded value, enabling better infrastructure customization without modifying deployment manifests directly.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PrivateAIM/helm/pull/134?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->