### PR TITLE
feat(authup): pass TRUSTED_ORIGINS to server-core, defaulting to t…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ Chart.lock
 !charts/flame-node/flame-node-data-store/charts/*.tgz
 *.pem
 docs/
+.claude

--- a/charts/flame-hub/values.yaml
+++ b/charts/flame-hub/values.yaml
@@ -172,6 +172,9 @@ auth:
 # Authentication Provider
 authup:
     publicHttps: false # global.flameHub.publicHttps also enables this
+    # Additional domains for which authorization is permitted (comma-separated string or list).
+    # Defaults to the public domain of the Hub UI (derived from the global ingress/gatewayApi hostname).
+    additionalDomains: ""
     image:
         repository: "authup/authup"
         tag: "latest"

--- a/charts/flame-hub/values.yaml
+++ b/charts/flame-hub/values.yaml
@@ -173,8 +173,10 @@ auth:
 authup:
     publicHttps: false # global.flameHub.publicHttps also enables this
     # Additional domains for which authorization is permitted (comma-separated string or list).
+    # The value is rendered as a Helm template inside the authup subchart context.
     # Defaults to the public domain of the Hub UI (derived from the global ingress/gatewayApi hostname).
-    additionalDomains: ""
+    # If the client UI uses its own hostname (per-service routing), set this explicitly.
+    additionalDomains: '{{- if or .Values.global.flameHub.ingress.enabled .Values.global.flameHub.gatewayApi.enabled }}{{ include "flameHub.uiDomain" . }}{{- end }}'
     image:
         repository: "authup/authup"
         tag: "latest"

--- a/charts/flame-hub/values.yaml
+++ b/charts/flame-hub/values.yaml
@@ -172,11 +172,12 @@ auth:
 # Authentication Provider
 authup:
     publicHttps: false # global.flameHub.publicHttps also enables this
-    # Additional domains for which authorization is permitted (comma-separated string or list).
+    # Trusted first-party application origins (redirect allowlist for the web client; not CORS).
+    # Accepts a comma-separated string or list; bare hosts expand to both http and https origins.
     # The value is rendered as a Helm template inside the authup subchart context.
     # Defaults to the public domain of the Hub UI (derived from the global ingress/gatewayApi hostname).
     # If the client UI uses its own hostname (per-service routing), set this explicitly.
-    additionalDomains: '{{- if or .Values.global.flameHub.ingress.enabled .Values.global.flameHub.gatewayApi.enabled }}{{ include "flameHub.uiDomain" . }}{{- end }}'
+    trustedOrigins: '{{- if or .Values.global.flameHub.ingress.enabled .Values.global.flameHub.gatewayApi.enabled }}{{ include "flameHub.uiDomain" . }}{{- end }}'
     image:
         repository: "authup/authup"
         tag: "latest"

--- a/charts/third-party/authup/templates/deployment.yaml
+++ b/charts/third-party/authup/templates/deployment.yaml
@@ -47,12 +47,12 @@ spec:
               -   name: PUBLIC_URL
                   value: "{{- toString . | trim }}"
             {{- end }}
-            {{- $additionalDomains := .Values.additionalDomains }}
-            {{- if kindIs "slice" $additionalDomains }}
-              {{- $additionalDomains = join "," $additionalDomains }}
+            {{- $trustedOrigins := .Values.trustedOrigins }}
+            {{- if kindIs "slice" $trustedOrigins }}
+              {{- $trustedOrigins = join "," $trustedOrigins }}
             {{- end }}
-            {{- with tpl (toString ($additionalDomains | default "")) $ | trim }}
-              -   name: ADDITIONAL_DOMAINS
+            {{- with tpl (toString ($trustedOrigins | default "")) $ | trim }}
+              -   name: TRUSTED_ORIGINS
                   value: {{ . | quote }}
             {{- end }}
             {{- if .Values.auth.existingSecret }}

--- a/charts/third-party/authup/templates/deployment.yaml
+++ b/charts/third-party/authup/templates/deployment.yaml
@@ -47,6 +47,20 @@ spec:
               -   name: PUBLIC_URL
                   value: "{{- toString . | trim }}"
             {{- end }}
+            {{- $additionalDomains := .Values.additionalDomains }}
+            {{- if kindIs "slice" $additionalDomains }}
+              {{- $additionalDomains = join "," $additionalDomains }}
+            {{- end }}
+            {{- if not $additionalDomains }}
+              {{- $flameHub := dig "flameHub" dict (.Values.global | default dict) }}
+              {{- if or (dig "ingress" "enabled" false $flameHub) (dig "gatewayApi" "enabled" false $flameHub) }}
+                {{- $additionalDomains = include "flameHub.uiDomain" . }}
+              {{- end }}
+            {{- end }}
+            {{- with $additionalDomains }}
+              -   name: ADDITIONAL_DOMAINS
+                  value: "{{- toString . | trim }}"
+            {{- end }}
             {{- if .Values.auth.existingSecret }}
               -   name: REDIS
                   valueFrom:

--- a/charts/third-party/authup/templates/deployment.yaml
+++ b/charts/third-party/authup/templates/deployment.yaml
@@ -51,15 +51,9 @@ spec:
             {{- if kindIs "slice" $additionalDomains }}
               {{- $additionalDomains = join "," $additionalDomains }}
             {{- end }}
-            {{- if not $additionalDomains }}
-              {{- $flameHub := dig "flameHub" dict (.Values.global | default dict) }}
-              {{- if or (dig "ingress" "enabled" false $flameHub) (dig "gatewayApi" "enabled" false $flameHub) }}
-                {{- $additionalDomains = include "flameHub.uiDomain" . }}
-              {{- end }}
-            {{- end }}
-            {{- with $additionalDomains }}
+            {{- with tpl (toString ($additionalDomains | default "")) $ | trim }}
               -   name: ADDITIONAL_DOMAINS
-                  value: "{{- toString . | trim }}"
+                  value: {{ . | quote }}
             {{- end }}
             {{- if .Values.auth.existingSecret }}
               -   name: REDIS

--- a/charts/third-party/authup/values.yaml
+++ b/charts/third-party/authup/values.yaml
@@ -23,8 +23,10 @@ auth:
 
 cookieDomain: ""
 publicURL: ""
-# Additional domains for which authorization is permitted.
-# Accepts a comma-separated string or a list of domains.
+# Trusted first-party application origins (redirect allowlist for the web client; not CORS).
+# Accepts a comma-separated string or a list. Each entry is either a bare host[:port]
+# (e.g. "hub.local", which expands to both its http and https origin) or an explicit-scheme
+# origin (e.g. "https://hub.local", which contributes exactly that origin). Only http/https.
 # The value is rendered as a Helm template (tpl), so a parent chart may inject
 # its own helpers, e.g. '{{ include "flameHub.uiDomain" . }}'.
-additionalDomains: ""
+trustedOrigins: ""

--- a/charts/third-party/authup/values.yaml
+++ b/charts/third-party/authup/values.yaml
@@ -25,5 +25,6 @@ cookieDomain: ""
 publicURL: ""
 # Additional domains for which authorization is permitted.
 # Accepts a comma-separated string or a list of domains.
-# When deployed as part of the flame-hub chart, this defaults to the public domain of the Hub UI.
+# The value is rendered as a Helm template (tpl), so a parent chart may inject
+# its own helpers, e.g. '{{ include "flameHub.uiDomain" . }}'.
 additionalDomains: ""

--- a/charts/third-party/authup/values.yaml
+++ b/charts/third-party/authup/values.yaml
@@ -23,3 +23,7 @@ auth:
 
 cookieDomain: ""
 publicURL: ""
+# Additional domains for which authorization is permitted.
+# Accepts a comma-separated string or a list of domains.
+# When deployed as part of the flame-hub chart, this defaults to the public domain of the Hub UI.
+additionalDomains: ""


### PR DESCRIPTION
…he hub UI public domain.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configure additional authorized web client origins (accepts comma-separated string or list) to allow extra permitted authorization origins.
* **Documentation**
  * Added guidance on how origin entries are interpreted and how to supply per-service hostnames.
* **Chores**
  * Updated ignore rules to exclude local tool artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->