### PR TITLE
chore(hub): remove Loki orphan config

### DIFF
--- a/charts/flame-hub/templates/grafana/datasources.yaml
+++ b/charts/flame-hub/templates/grafana/datasources.yaml
@@ -2,32 +2,24 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: grafana-datasources
+    name: grafana-datasources
 type: Opaque
 stringData:
-  datasources.yaml: |
-    apiVersion: 1
-    datasources:
-      - name: Prometheus
-        type: prometheus
-        access: proxy
-        url: http://{{ .Release.Name }}-prometheus-server:9090
-        jsonData:
-          httpMethod: POST
-          manageAlerts: true
-          prometheusType: Prometheus
-          prometheusVersion: 2.44.0
-          cacheLevel: 'High'
-          disableRecordingRules: false
-          incrementalQueryOverlapWindow: 10m
-      - name: Loki
-        type: loki
-        access: proxy
-        url: http://{{ .Release.Name }}-loki-query-frontend:3100
-        jsonData:
-          timeout: 60
-          maxLines: 1000
-      - name: VL
-        type: victoriametrics-logs-datasource
-        url: http://{{ .Release.Name }}-victoria-logs-vlselect:9471
-
+    datasources.yaml: |
+        apiVersion: 1
+        datasources:
+          - name: Prometheus
+            type: prometheus
+            access: proxy
+            url: http://{{ .Release.Name }}-prometheus-server:9090
+            jsonData:
+              httpMethod: POST
+              manageAlerts: true
+              prometheusType: Prometheus
+              prometheusVersion: 2.44.0
+              cacheLevel: 'High'
+              disableRecordingRules: false
+              incrementalQueryOverlapWindow: 10m
+          - name: VL
+            type: victoriametrics-logs-datasource
+            url: http://{{ .Release.Name }}-victoria-logs-vlselect:9471

--- a/charts/flame-hub/values.yaml
+++ b/charts/flame-hub/values.yaml
@@ -334,39 +334,6 @@ victoria-logs-cluster:
         retentionPeriod: "100y"
         retentionDiskSpaceUsage: "50GiB"
 
-grafana-loki:
-    nameOverride: "loki"
-    loki:
-        image:
-            #repository: "tada5hi/grafana-loki"
-            repository: "bitnamilegacy/grafana-loki"
-            tag: "3.5.3-debian-12-r2"
-        overrideConfiguration:
-            limits_config:
-                deletion_mode: "filter-and-delete"
-    gateway:
-        image:
-            #repository: "tada5hi/nginx"
-            repository: "bitnamilegacy/nginx"
-            tag: "1.29.1-debian-12-r0"
-    memcachedfrontend:
-        image:
-            repository: "bitnamilegacy/memcached"
-            tag: "1.6.39-debian-12-r0"
-    memcachedchunks:
-        image:
-            repository: "bitnamilegacy/memcached"
-            tag: "1.6.39-debian-12-r0"
-    grafanaalloy:
-        alloy:
-            image:
-                repository: "bitnamilegacy/grafana-alloy"
-                tag: "1.10.1-debian-12-r1"
-        configReloader:
-            image:
-                repository: "bitnamilegacy/configmap-reload"
-                tag: "0.15.0-debian-12-r12"
-
 prometheus:
     nameOverride: "prometheus"
     alertmanager:


### PR DESCRIPTION
or do we still need this?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified Grafana datasource configuration to keep only Prometheus and VictoriaMetrics logs.
  * Removed the Loki datasource and its related chart settings from the default values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->