### PR TITLE
chore(values): bump image tag to 0.6.0

### DIFF
--- a/charts/flame-node/values.yaml
+++ b/charts/flame-node/values.yaml
@@ -511,7 +511,7 @@ podOrchestrator:
     repository: ghcr.io/privateaim/node-pod-orchestration
     # Overrides the image tag whose default is the chart appVersion.
     # TODO: update to new version once available after testing
-    tag: 0.5.5
+    tag: 0.6.0
     # This sets the pull policy for images.
     pullPolicy: IfNotPresent
 


### PR DESCRIPTION
changes see https://github.com/PrivateAIM/node-pod-orchestration/pull/52