### PR TITLE
Seaweedfs security

### DIFF
--- a/charts/flame-node/flame-node-data-store/values.yaml
+++ b/charts/flame-node/flame-node-data-store/values.yaml
@@ -48,7 +48,7 @@ seaweedfs:
       limits:
         cpu: "1"
         memory: 1Gi
-   podSecurityContext:
+    podSecurityContext:
       enabled: true
       runAsUser: 1000
       runAsGroup: 1000

--- a/charts/flame-node/flame-node-data-store/values.yaml
+++ b/charts/flame-node/flame-node-data-store/values.yaml
@@ -48,9 +48,41 @@ seaweedfs:
       limits:
         cpu: "1"
         memory: 1Gi
+   podSecurityContext:
+      enabled: true
+      runAsUser: 1000
+      runAsGroup: 1000
+      fsGroup: 1000
+      runAsNonRoot: true
+      seccompProfile:
+        type: RuntimeDefault
+    containerSecurityContext:
+      enabled: true
+      runAsUser: 1000
+      runAsGroup: 1000
+      runAsNonRoot: true
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop: ["ALL"]
 
   admin:
     enabled: true
+    podSecurityContext:
+      enabled: true
+      runAsUser: 1000
+      runAsGroup: 1000
+      fsGroup: 1000
+      runAsNonRoot: true
+      seccompProfile:
+        type: RuntimeDefault
+    containerSecurityContext:
+      enabled: true
+      runAsUser: 1000
+      runAsGroup: 1000
+      runAsNonRoot: true
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop: ["ALL"]
     ## Single-node: drop the chart's default hard pod anti-affinity (same reason as allInOne above).
     affinity: ""
     ## Required: the admin must be told the master address because the standalone master is disabled

--- a/charts/flame-node/templates/_helpers.tpl
+++ b/charts/flame-node/templates/_helpers.tpl
@@ -24,6 +24,30 @@ true
 {{- end -}}
 
 {{/*
+Return the URL scheme for components: "https" when a TLS secret is configured via expose.tls.secretName, otherwise "http".
+*/}}
+{{- define "hostname.protocol" -}}
+{{- if .Values.expose.tls.secretName -}}
+https
+{{- else -}}
+http
+{{- end -}}
+{{- end -}}
+
+{{/*
+Prefix a hostname with a scheme, defaulting via node.scheme when the hostname doesn't already include one.
+*/}}
+{{- define "hostname.withProtocol" -}}
+{{- $hostname := index . 0 -}}
+{{- $ctx := index . 1 -}}
+{{- if hasPrefix "http" $hostname -}}
+    {{- $hostname -}}
+{{- else -}}
+    {{- printf "%s://%s" (include "hostname.protocol" $ctx) $hostname -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Return the normalized hostname for all node components. Source of truth: expose.hostname.
 */}}
 {{- define "node.hostname" -}}
@@ -31,11 +55,7 @@ Return the normalized hostname for all node components. Source of truth: expose.
     {{- fail "expose.hostname must be set when expose.type is 'ingress' or 'gateway'" -}}
 {{- end -}}
 {{- if .Values.expose.hostname -}}
-    {{- if hasPrefix "http" .Values.expose.hostname -}}
-        {{- .Values.expose.hostname -}}
-    {{- else -}}
-        {{- printf "http://%s" .Values.expose.hostname -}}
-    {{- end -}}
+    {{- include "hostname.withProtocol" (list .Values.expose.hostname .) -}}
 {{- else -}}
     {{- "http://localhost:3000" -}}
 {{- end -}}
@@ -189,11 +209,7 @@ Return the hub adapter endpoint
 */}}
 {{- define "ui.adapter.endpoint" -}}
 {{- if and (ne .Values.expose.type "none") .Values.expose.hostname (not (contains "localhost" .Values.expose.hostname)) -}}
-    {{- if hasPrefix "http" .Values.expose.hostname -}}
-        {{- printf "%s/api" .Values.expose.hostname -}}
-    {{- else -}}
-        {{- printf "http://%s/api" .Values.expose.hostname -}}
-    {{- end -}}
+    {{- printf "%s/api" (include "hostname.withProtocol" (list .Values.expose.hostname .)) -}}
 {{- else -}}
     {{- print "http://localhost:5000" -}}
 {{- end -}}

--- a/charts/flame-node/templates/message-broker/deployment.yml
+++ b/charts/flame-node/templates/message-broker/deployment.yml
@@ -50,7 +50,10 @@ spec:
           securityContext:
             {{- toYaml .Values.messageBroker.securityContext | nindent 12 }}
           ports:
-            - containerPort: 8080
+            - name: http
+              containerPort: 8080
+            - name: actuator
+              containerPort: 8090
           env:
             - name: TZ
               value: {{ .Values.timezone | default "Europe/Berlin" }}

--- a/charts/flame-node/templates/message-broker/service.yml
+++ b/charts/flame-node/templates/message-broker/service.yml
@@ -19,3 +19,7 @@ spec:
   ports:
     - port: 80
       targetPort: 8080
+      name: http
+    - port: 8090
+      targetPort: 8090
+      name: actuator

--- a/charts/flame-node/values.yaml
+++ b/charts/flame-node/values.yaml
@@ -863,10 +863,42 @@ dataStore:
       data:
         type: persistentVolumeClaim
         size: 5Gi
+      podSecurityContext:
+        enabled: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containerSecurityContext:
+        enabled: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        runAsNonRoot: true
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop: ["ALL"]
 
     ## Admin UI dashboard for browsing/creating buckets and cluster management
     admin:
       enabled: true
+      podSecurityContext:
+        enabled: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containerSecurityContext:
+        enabled: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        runAsNonRoot: true
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop: ["ALL"]
 
       ## Expose the admin panel in the browser via the node Ingress API
       ingress:
@@ -1117,6 +1149,22 @@ seaweedfs:
     data:
       type: persistentVolumeClaim
       size: 10Gi
+    podSecurityContext:
+      enabled: true
+      runAsUser: 1000
+      runAsGroup: 1000
+      fsGroup: 1000
+      runAsNonRoot: true
+      seccompProfile:
+        type: RuntimeDefault
+    containerSecurityContext:
+      enabled: true
+      runAsUser: 1000
+      runAsGroup: 1000
+      runAsNonRoot: true
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop: ["ALL"]
 
 mongodb:
   ## Pull secrets and name override options


### PR DESCRIPTION
- Added specific security contexts to the SeaweedFS deployments for both the `flame-node` and `flame-node-data-store` charts to ensure security compliance for clusters that do not allow containers to run as `root`, closes #156 
- Added new helper functions to the `flame-node` to automatically select `https` as the protocol for the provided ingress/gateway hostname if a TLS secret is provided and a protocol is not already present in the string, closes #158 
- Create a new service port for the node message broker which allows the hub adapter to perform health checks, closes #157 