### PR TITLE
feat!(hub): replace bitnami postgres chart with self managed postgres statefulset

### DIFF
--- a/charts/flame-hub/Chart.yaml
+++ b/charts/flame-hub/Chart.yaml
@@ -8,9 +8,6 @@ dependencies:
   - name: common
     version: 2.31.4
     repository: oci://registry-1.docker.io/bitnamicharts
-  - name: postgresql
-    version: 18.5.1
-    repository: oci://registry-1.docker.io/bitnamicharts
   - name: redis
     version: 22.0.6
     repository: oci://registry-1.docker.io/bitnamicharts

--- a/charts/flame-hub/README.md
+++ b/charts/flame-hub/README.md
@@ -83,6 +83,29 @@ kubectl create secret generic flame-hub-auth \
   # ...
 ```
 
+> **Note:** The chart-managed Secrets carry `helm.sh/resource-policy: keep, so they are not removed upon a `helm uninstall`. This is because PVCs are also retained so they share the same lifecyle.
+
+## Running Multiple Releases in the Same Namespace
+
+Most resources are release-scoped (prefixed with the release name), so several installs can normally coexist in one namespace. **However, some subcharts cannot template values, so we need to provide them with hardcoded ones.** For example, the goharbor chart cannot template its Postgres service name and secret name. The FLAME-Hub comes with working defaults, but running multiple instances in one namespace requires action.
+
+You must give each release its own value for:
+
+| Value | Default | What it names |
+| --- | --- | --- |
+| `global.flameHub.postgresql.host` | `postgresql` | The headless PostgreSQL Service |
+| `global.flameHub.postgresql.secretName` | `flame-hub-pg` | The chart-managed PostgreSQL credential Secret |
+| `harbor.externalDatabase.host` | `postgresql` | Harbor's DB host — **must match** `global.flameHub.postgresql.host` |
+| `harbor.externalDatabase.existingSecret` | `flame-hub-pg` | Harbor's DB secret — **must match** the effective PostgreSQL secret |
+| `auth.secretName` | `flame-hub-auth` | central chart secret for other service credentials |
+| `authup.auth.existingSecret` | `flame-hub-auth` | subchart reference — **must match** `auth.secretName` |
+| `rabbitmq.auth.existingPasswordSecret` | `flame-hub-auth` | subchart reference — **must match** `auth.secretName` |
+| `redis.auth.existingSecret` | `flame-hub-auth` | subchart reference — **must match** `auth.secretName` |
+| `grafana.admin.existingSecret` | `flame-hub-auth` | subchart reference — **must match** `auth.secretName` |
+| `harbor.existingSecret` | `flame-hub-auth` | subchart reference — **must match** `auth.secretName` |
+
+If you bring your own PostgreSQL Secret via `global.flameHub.postgresql.existingSecret`, that name must be unique per release too, and Harbor's `externalDatabase.existingSecret` must point at the same secret (key `password`).
+
 ## Installing the FLAME Hub Chart
 
 ### 1. Option: Official Chart Repo

--- a/charts/flame-hub/README.md
+++ b/charts/flame-hub/README.md
@@ -66,14 +66,11 @@ The difference is that `existingSecret` is not populated with values from the ch
 The chart requires a secret with the following keys:
 
 ```
-postgresql-password:
-postgresql-replication-password:
 rabbitmq-password:
 redis-password:
 harbor-admin-password:
 grafana-admin-password:
 authup-admin-password:
-postgresql-connection-string:
 redis-connection-string:
 rabbitmq-connection-string:
 harbor-connection-string:
@@ -82,7 +79,6 @@ client-secret:
 Create a secret:
 ```bash
 kubectl create secret generic flame-hub-auth \
-  --from-literal=postgresql-password=verysecurepassword \
   --from-literal=harbor-admin-password=anothersecurepassword \
   # ...
 ```

--- a/charts/flame-hub/README.md
+++ b/charts/flame-hub/README.md
@@ -104,7 +104,7 @@ You must give each release its own value for:
 | `grafana.admin.existingSecret` | `flame-hub-auth` | subchart reference — **must match** `auth.secretName` |
 | `harbor.existingSecret` | `flame-hub-auth` | subchart reference — **must match** `auth.secretName` |
 
-If you bring your own PostgreSQL Secret via `global.flameHub.postgresql.existingSecret`, that name must be unique per release too, and Harbor's `externalDatabase.existingSecret` must point at the same secret (key `password`).
+If you bring your own PostgreSQL Secret via `global.flameHub.postgresql.existingSecret`, that name must be unique per release too, and Harbor's `externalDatabase.existingSecret` must point at the same secret. The Secret must contain both a `username` and a `password` key.
 
 ## Installing the FLAME Hub Chart
 

--- a/charts/flame-hub/templates/_helpers.tpl
+++ b/charts/flame-hub/templates/_helpers.tpl
@@ -74,6 +74,16 @@ Create the name of the service account to use
 {{- end -}}
 {{- end -}}
 
+
+{{- define "flameHub.postgresql.host" -}}
+{{- required "global.flameHub.postgresql.host is required" .Values.global.flameHub.postgresql.host -}}
+{{- end -}}
+
+{{- define "flameHub.postgresql.secretName" -}}
+{{- $pg := .Values.global.flameHub.postgresql -}}
+{{- $pg.existingSecret | default (required "global.flameHub.postgresql.secretName is required" $pg.secretName) -}}
+{{- end -}}
+
 {{/*
 Full name of the seaweedfs subchart release, mirroring its "seaweedfs.fullname" helper
 so resource names can be derived from the parent chart context (fullnameOverride is not respected).

--- a/charts/flame-hub/templates/credentials-secret.yaml
+++ b/charts/flame-hub/templates/credentials-secret.yaml
@@ -14,8 +14,6 @@ type: Opaque
 stringData:
 
   # Get overrides from values
-  {{- $postgresPassword := .Values.postgresql.auth.postgresPassword | default "" }}
-  {{- $postgresReplicationPassword := .Values.postgresql.auth.replicationPassword | default "" }}
   {{- $rabbitmqPassword := .Values.rabbitmq.auth.password | default "" }}
   {{- $redisPassword := .Values.redis.auth.password | default "" }}
   {{- $harborAdminPassword := .Values.harbor.adminPassword | default "" }}
@@ -25,12 +23,6 @@ stringData:
 
   # Fill empty values with existing secret values if available
   {{- if and $existingSecret $existingSecret.data }}
-    {{- if and (not $postgresPassword) (hasKey $existingSecret.data "postgresql-password") }}
-      {{- $postgresPassword = index $existingSecret.data "postgresql-password" | b64dec }}
-    {{- end }}
-    {{- if and (not $postgresReplicationPassword) (hasKey $existingSecret.data "postgresql-replication-password") }}
-      {{- $postgresReplicationPassword = index $existingSecret.data "postgresql-replication-password" | b64dec }}
-    {{- end }}
     {{- if and (not $rabbitmqPassword) (hasKey $existingSecret.data "rabbitmq-password") }}
       {{- $rabbitmqPassword = index $existingSecret.data "rabbitmq-password" | b64dec }}
     {{- end }}
@@ -52,8 +44,6 @@ stringData:
   {{- end }}
 
   # Generate any missing values
-  {{- if not $postgresPassword }}{{ $postgresPassword = randAlphaNum 32 }}{{- end }}
-  {{- if not $postgresReplicationPassword }}{{ $postgresReplicationPassword = randAlphaNum 32 }}{{- end }}
   {{- if not $rabbitmqPassword }}{{ $rabbitmqPassword = randAlphaNum 32 }}{{- end }}
   {{- if not $redisPassword }}{{ $redisPassword = randAlphaNum 32 }}{{- end }}
   {{- if not $harborAdminPassword }}{{ $harborAdminPassword = randAlphaNum 32 }}{{- end }}
@@ -61,9 +51,8 @@ stringData:
   {{- if not $authupAdminPassword }}{{ $authupAdminPassword = randAlphaNum 32 }}{{- end }}
   {{- if not $authupClientSecret }}{{ $authupClientSecret = randAlphaNum 32 }}{{- end }}
 
-  # Actual values in the secret
-  postgresql-password: {{ $postgresPassword | quote }}
-  postgresql-replication-password: {{ $postgresReplicationPassword | quote }}
+  # Actual values in the secret.
+  # No postgresql-* keys: that credential lives in templates/postgresql/secret.yaml.
   rabbitmq-password: {{ $rabbitmqPassword | quote }}
   redis-password: {{ $redisPassword | quote }}
   harbor-admin-password: {{ $harborAdminPassword | quote }}
@@ -72,7 +61,6 @@ stringData:
   authup-client-secret: {{ $authupClientSecret | quote }}
 
   # Connection strings (pre-built with passwords)
-  postgresql-connection-string: {{ printf "postgresql://postgres:%s@%s-postgresql-primary:5432" ($postgresPassword | urlquery) .Release.Name | quote }}
   redis-connection-string: {{ printf "redis://default:%s@%s-redis-master:6379" ($redisPassword | urlquery) .Release.Name | quote }}
   rabbitmq-connection-string: {{ printf "amqp://%s:%s@%s-rabbitmq:5672" (.Values.rabbitmq.auth.username | urlquery) ($rabbitmqPassword | urlquery) .Release.Name | quote }}
   {{- if include "harbor.host" . }}

--- a/charts/flame-hub/templates/postgresql/configmap-init.yaml
+++ b/charts/flame-hub/templates/postgresql/configmap-init.yaml
@@ -1,0 +1,19 @@
+# Mounted at /docker-entrypoint-initdb.d. The official postgres image runs these
+# scripts (via psql, ON_ERROR_STOP=1) only on first initialisation of an empty
+# data directory, mirroring the previous Bitnami initdb behaviour.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+    name: "{{ .Release.Name }}-postgresql-init"
+    labels:
+        app: "{{ .Release.Name }}-postgresql"
+data:
+    01-init-databases.sql: |
+        {{- range .Values.postgresql.databases }}
+        CREATE DATABASE "{{ . }}" ENCODING 'UTF8';
+        {{- end }}
+        {{- if has "registry" .Values.postgresql.databases }}
+        -- Harbor expects its migration bookkeeping table to exist up-front.
+        \connect registry
+        CREATE TABLE IF NOT EXISTS schema_migrations(version bigint not null primary key, dirty boolean not null);
+        {{- end }}

--- a/charts/flame-hub/templates/postgresql/secret.yaml
+++ b/charts/flame-hub/templates/postgresql/secret.yaml
@@ -4,7 +4,6 @@ Chart-managed PostgreSQL credential. Skipped entirely when the user brings their
 */}}
 {{- if not .Values.global.flameHub.postgresql.existingSecret }}
 {{- $existingPgSecret := lookup "v1" "Secret" .Release.Namespace (include "flameHub.postgresql.secretName" .) }}
-{{- $legacyAuthSecret := lookup "v1" "Secret" .Release.Namespace .Values.auth.secretName }}
 
 {{/* Resolution order matters — see the comment on each step. */}}
 {{- $postgresPassword := .Values.postgresql.auth.postgresPassword | default "" }}
@@ -12,13 +11,7 @@ Chart-managed PostgreSQL credential. Skipped entirely when the user brings their
 {{- if and (not $postgresPassword) $existingPgSecret $existingPgSecret.data (hasKey $existingPgSecret.data "password") }}
   {{- $postgresPassword = index $existingPgSecret.data "password" | b64dec }}
 {{- end }}
-{{/* 2. Upgrade path: before the split, the password lived in the chart-managed auth Secret
-     under "postgresql-password". Adopting it is required, not cosmetic: Postgres only
-     honours POSTGRES_PASSWORD on initdb of an empty data dir, so an existing PVC still
-     expects the old value and generating a fresh one would lock the database out. */}}
-{{- if and (not $postgresPassword) $legacyAuthSecret $legacyAuthSecret.data (hasKey $legacyAuthSecret.data "postgresql-password") }}
-  {{- $postgresPassword = index $legacyAuthSecret.data "postgresql-password" | b64dec }}
-{{- end }}
+{{/* 2. Fresh install only: no existing Secret and no override -> generate. */}}
 {{- if not $postgresPassword }}{{- $postgresPassword = randAlphaNum 32 }}{{- end }}
 
 apiVersion: v1

--- a/charts/flame-hub/templates/postgresql/secret.yaml
+++ b/charts/flame-hub/templates/postgresql/secret.yaml
@@ -1,0 +1,36 @@
+{{/*
+Chart-managed PostgreSQL credential. Skipped entirely when the user brings their own
+(global.flameHub.postgresql.existingSecret)
+*/}}
+{{- if not .Values.global.flameHub.postgresql.existingSecret }}
+{{- $existingPgSecret := lookup "v1" "Secret" .Release.Namespace (include "flameHub.postgresql.secretName" .) }}
+{{- $legacyAuthSecret := lookup "v1" "Secret" .Release.Namespace .Values.auth.secretName }}
+
+{{/* Resolution order matters — see the comment on each step. */}}
+{{- $postgresPassword := .Values.postgresql.auth.postgresPassword | default "" }}
+{{/* 1. Steady state: this Secret is its own source of truth across upgrades. */}}
+{{- if and (not $postgresPassword) $existingPgSecret $existingPgSecret.data (hasKey $existingPgSecret.data "password") }}
+  {{- $postgresPassword = index $existingPgSecret.data "password" | b64dec }}
+{{- end }}
+{{/* 2. Upgrade path: before the split, the password lived in the chart-managed auth Secret
+     under "postgresql-password". Adopting it is required, not cosmetic: Postgres only
+     honours POSTGRES_PASSWORD on initdb of an empty data dir, so an existing PVC still
+     expects the old value and generating a fresh one would lock the database out. */}}
+{{- if and (not $postgresPassword) $legacyAuthSecret $legacyAuthSecret.data (hasKey $legacyAuthSecret.data "postgresql-password") }}
+  {{- $postgresPassword = index $legacyAuthSecret.data "postgresql-password" | b64dec }}
+{{- end }}
+{{- if not $postgresPassword }}{{- $postgresPassword = randAlphaNum 32 }}{{- end }}
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "flameHub.postgresql.secretName" . | quote }}
+  labels:
+    app: {{ .Release.Name }}-flame-hub
+  annotations:
+    "helm.sh/resource-policy": keep
+type: kubernetes.io/basic-auth
+stringData:
+  username: {{ .Values.postgresql.auth.username | quote }}
+  password: {{ $postgresPassword | quote }}
+{{- end }}

--- a/charts/flame-hub/templates/postgresql/service.yaml
+++ b/charts/flame-hub/templates/postgresql/service.yaml
@@ -1,26 +1,7 @@
-# Client-facing service. The "-postgresql-primary" suffix is kept identical to the
-# previous Bitnami subchart so Harbor's externalDatabase, authup and the server-*
-# services connect without any per-release overrides.
 apiVersion: v1
 kind: Service
 metadata:
-    name: "{{ .Release.Name }}-postgresql-primary"
-    labels:
-        app: "{{ .Release.Name }}-postgresql"
-spec:
-    selector:
-        app: "{{ .Release.Name }}-postgresql"
-    ports:
-        -   name: postgresql
-            protocol: TCP
-            port: {{ .Values.postgresql.service.port }}
-            targetPort: postgresql
----
-# Headless service governing the StatefulSet (stable pod DNS).
-apiVersion: v1
-kind: Service
-metadata:
-    name: "{{ .Release.Name }}-postgresql-headless"
+    name: {{ include "flameHub.postgresql.host" . | quote }}
     labels:
         app: "{{ .Release.Name }}-postgresql"
 spec:

--- a/charts/flame-hub/templates/postgresql/service.yaml
+++ b/charts/flame-hub/templates/postgresql/service.yaml
@@ -1,0 +1,34 @@
+# Client-facing service. The "-postgresql-primary" suffix is kept identical to the
+# previous Bitnami subchart so Harbor's externalDatabase, authup and the server-*
+# services connect without any per-release overrides.
+apiVersion: v1
+kind: Service
+metadata:
+    name: "{{ .Release.Name }}-postgresql-primary"
+    labels:
+        app: "{{ .Release.Name }}-postgresql"
+spec:
+    selector:
+        app: "{{ .Release.Name }}-postgresql"
+    ports:
+        -   name: postgresql
+            protocol: TCP
+            port: {{ .Values.postgresql.service.port }}
+            targetPort: postgresql
+---
+# Headless service governing the StatefulSet (stable pod DNS).
+apiVersion: v1
+kind: Service
+metadata:
+    name: "{{ .Release.Name }}-postgresql-headless"
+    labels:
+        app: "{{ .Release.Name }}-postgresql"
+spec:
+    clusterIP: None
+    selector:
+        app: "{{ .Release.Name }}-postgresql"
+    ports:
+        -   name: postgresql
+            protocol: TCP
+            port: {{ .Values.postgresql.service.port }}
+            targetPort: postgresql

--- a/charts/flame-hub/templates/postgresql/statefulset.yaml
+++ b/charts/flame-hub/templates/postgresql/statefulset.yaml
@@ -1,0 +1,81 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+    name: "{{ .Release.Name }}-postgresql"
+    labels:
+        app: "{{ .Release.Name }}-postgresql"
+spec:
+    serviceName: "{{ .Release.Name }}-postgresql-headless"
+    replicas: 1
+    selector:
+        matchLabels:
+            app: "{{ .Release.Name }}-postgresql"
+    template:
+        metadata:
+            labels:
+                app: "{{ .Release.Name }}-postgresql"
+        spec:
+            {{- with .Values.postgresql.podSecurityContext }}
+            securityContext: {{- toYaml . | nindent 16 }}
+            {{- end }}
+            containers:
+                -   name: postgresql
+                    image: "{{ .Values.postgresql.image.repository }}:{{ .Values.postgresql.image.tag }}"
+                    imagePullPolicy: {{ .Values.postgresql.image.pullPolicy }}
+                    {{- with .Values.postgresql.extraArgs }}
+                    args:
+                        {{- toYaml . | nindent 24 }}
+                    {{- end }}
+                    env:
+                        -   name: POSTGRES_USER
+                            value: {{ .Values.postgresql.auth.username | quote }}
+                        -   name: POSTGRES_PASSWORD
+                            valueFrom:
+                                secretKeyRef:
+                                    name: {{ include "flameHub.effectiveSecretName" . }}
+                                    key: {{ .Values.postgresql.auth.secretPasswordKey }}
+                        # Keep PGDATA in a sub-directory of the mount so a fresh PVC
+                        # (which may contain lost+found) does not block initdb.
+                        -   name: PGDATA
+                            value: /var/lib/postgresql/data/pgdata
+                    ports:
+                        -   name: postgresql
+                            containerPort: 5432
+                    readinessProbe:
+                        exec:
+                            command: ["pg_isready", "-U", {{ .Values.postgresql.auth.username | quote }}, "-d", "postgres"]
+                        initialDelaySeconds: 10
+                        periodSeconds: 10
+                        timeoutSeconds: 5
+                        failureThreshold: 20
+                    livenessProbe:
+                        exec:
+                            command: ["pg_isready", "-U", {{ .Values.postgresql.auth.username | quote }}, "-d", "postgres"]
+                        initialDelaySeconds: 30
+                        periodSeconds: 10
+                        timeoutSeconds: 5
+                        failureThreshold: 6
+                    {{- with .Values.postgresql.resources }}
+                    resources: {{- toYaml . | nindent 24 }}
+                    {{- end }}
+                    volumeMounts:
+                        -   name: data
+                            mountPath: /var/lib/postgresql/data
+                        -   name: init
+                            mountPath: /docker-entrypoint-initdb.d
+                            readOnly: true
+            volumes:
+                -   name: init
+                    configMap:
+                        name: "{{ .Release.Name }}-postgresql-init"
+    volumeClaimTemplates:
+        -   metadata:
+                name: data
+            spec:
+                accessModes: ["ReadWriteOnce"]
+                {{- with .Values.postgresql.persistence.storageClass }}
+                storageClassName: {{ . | quote }}
+                {{- end }}
+                resources:
+                    requests:
+                        storage: {{ .Values.postgresql.persistence.size }}

--- a/charts/flame-hub/templates/postgresql/statefulset.yaml
+++ b/charts/flame-hub/templates/postgresql/statefulset.yaml
@@ -28,7 +28,10 @@ spec:
                     {{- end }}
                     env:
                         -   name: POSTGRES_USER
-                            value: {{ .Values.postgresql.auth.username | quote }}
+                            valueFrom:
+                                secretKeyRef:
+                                    name: {{ include "flameHub.postgresql.secretName" . }}
+                                    key: username
                         -   name: POSTGRES_PASSWORD
                             valueFrom:
                                 secretKeyRef:

--- a/charts/flame-hub/templates/postgresql/statefulset.yaml
+++ b/charts/flame-hub/templates/postgresql/statefulset.yaml
@@ -5,7 +5,7 @@ metadata:
     labels:
         app: "{{ .Release.Name }}-postgresql"
 spec:
-    serviceName: "{{ .Release.Name }}-postgresql-headless"
+    serviceName: {{ include "flameHub.postgresql.host" . | quote }}
     replicas: 1
     selector:
         matchLabels:
@@ -32,8 +32,8 @@ spec:
                         -   name: POSTGRES_PASSWORD
                             valueFrom:
                                 secretKeyRef:
-                                    name: {{ include "flameHub.effectiveSecretName" . }}
-                                    key: {{ .Values.postgresql.auth.secretPasswordKey }}
+                                    name: {{ include "flameHub.postgresql.secretName" . }}
+                                    key: password
                         # Keep PGDATA in a sub-directory of the mount so a fresh PVC
                         # (which may contain lost+found) does not block initdb.
                         -   name: PGDATA

--- a/charts/flame-hub/templates/server-core/deployment.yaml
+++ b/charts/flame-hub/templates/server-core/deployment.yaml
@@ -95,7 +95,10 @@ spec:
               -   name: DB_HOST
                   value: {{ include "flameHub.postgresql.host" . | quote }}
               -   name: DB_USERNAME
-                  value: "postgres"
+                  valueFrom:
+                      secretKeyRef:
+                          name: {{ include "flameHub.postgresql.secretName" . }}
+                          key: username
               -   name: DB_PASSWORD
                   valueFrom:
                       secretKeyRef:

--- a/charts/flame-hub/templates/server-core/deployment.yaml
+++ b/charts/flame-hub/templates/server-core/deployment.yaml
@@ -29,7 +29,7 @@ spec:
               command: [
                   'sh',
                   '-c',
-                  'until nc -z -v -w30 {{ .Release.Name }}-postgresql-primary 5432; do echo "Waiting for db..."; sleep 5; done'
+                  'until nc -z -v -w30 {{ include "flameHub.postgresql.host" . }} 5432; do echo "Waiting for db..."; sleep 5; done'
               ]
           -   name: wait-for-redis
               image: busybox
@@ -93,14 +93,14 @@ spec:
               -   name: DB_TYPE
                   value: "postgres"
               -   name: DB_HOST
-                  value: "{{ .Release.Name }}-postgresql-primary"
+                  value: {{ include "flameHub.postgresql.host" . | quote }}
               -   name: DB_USERNAME
                   value: "postgres"
               -   name: DB_PASSWORD
                   valueFrom:
                       secretKeyRef:
-                          name: {{ include "flameHub.effectiveSecretName" .  }}
-                          key: postgresql-password
+                          name: {{ include "flameHub.postgresql.secretName" . }}
+                          key: password
               -   name: DB_DATABASE
                   value: "core"
               -   name: MASTER_IMAGES_BRANCH

--- a/charts/flame-hub/templates/server-messenger/deployment.yaml
+++ b/charts/flame-hub/templates/server-messenger/deployment.yaml
@@ -72,7 +72,10 @@ spec:
                         -   name: DB_HOST
                             value: {{ include "flameHub.postgresql.host" . | quote }}
                         -   name: DB_USERNAME
-                            value: "postgres"
+                            valueFrom:
+                                secretKeyRef:
+                                    name: {{ include "flameHub.postgresql.secretName" . }}
+                                    key: username
                         -   name: DB_PASSWORD
                             valueFrom:
                               secretKeyRef:

--- a/charts/flame-hub/templates/server-messenger/deployment.yaml
+++ b/charts/flame-hub/templates/server-messenger/deployment.yaml
@@ -23,7 +23,7 @@ spec:
                   command: [
                       'sh',
                       '-c',
-                      'until nc -z -v -w30 {{ .Release.Name }}-postgresql-primary 5432; do echo "Waiting for db..."; sleep 5; done'
+                      'until nc -z -v -w30 {{ include "flameHub.postgresql.host" . }} 5432; do echo "Waiting for db..."; sleep 5; done'
                     ]
                 -   name: wait-for-redis
                     image: busybox
@@ -70,14 +70,14 @@ spec:
                         -   name: DB_TYPE
                             value: "postgres"
                         -   name: DB_HOST
-                            value: "{{ .Release.Name }}-postgresql-primary"
+                            value: {{ include "flameHub.postgresql.host" . | quote }}
                         -   name: DB_USERNAME
                             value: "postgres"
                         -   name: DB_PASSWORD
                             valueFrom:
                               secretKeyRef:
-                                name: {{ include "flameHub.effectiveSecretName" .  }}
-                                key: postgresql-password
+                                name: {{ include "flameHub.postgresql.secretName" . }}
+                                key: password
                         -   name: DB_DATABASE
                             value: "messenger"
                         -   name: CLIENT_ID

--- a/charts/flame-hub/templates/server-storage/deployment.yaml
+++ b/charts/flame-hub/templates/server-storage/deployment.yaml
@@ -92,7 +92,10 @@ spec:
                         -   name: DB_HOST
                             value: {{ include "flameHub.postgresql.host" . | quote }}
                         -   name: DB_USERNAME
-                            value: "postgres"
+                            valueFrom:
+                                secretKeyRef:
+                                    name: {{ include "flameHub.postgresql.secretName" . }}
+                                    key: username
                         -   name: DB_PASSWORD
                             valueFrom:
                                 secretKeyRef:

--- a/charts/flame-hub/templates/server-storage/deployment.yaml
+++ b/charts/flame-hub/templates/server-storage/deployment.yaml
@@ -23,7 +23,7 @@ spec:
                     command: [
                         'sh',
                         '-c',
-                        'until nc -z -v -w30 {{ .Release.Name }}-postgresql-primary 5432; do echo "Waiting for db..."; sleep 5; done'
+                        'until nc -z -v -w30 {{ include "flameHub.postgresql.host" . }} 5432; do echo "Waiting for db..."; sleep 5; done'
                     ]
                 -   name: wait-for-redis
                     image: busybox
@@ -90,14 +90,14 @@ spec:
                         -   name: DB_TYPE
                             value: "postgres"
                         -   name: DB_HOST
-                            value: "{{ .Release.Name }}-postgresql-primary"
+                            value: {{ include "flameHub.postgresql.host" . | quote }}
                         -   name: DB_USERNAME
                             value: "postgres"
                         -   name: DB_PASSWORD
                             valueFrom:
                                 secretKeyRef:
-                                    name: {{ include "flameHub.effectiveSecretName" .  }}
-                                    key: postgresql-password
+                                    name: {{ include "flameHub.postgresql.secretName" . }}
+                                    key: password
                         -   name: DB_DATABASE
                             value: "storage"
                         -   name: CLIENT_ID

--- a/charts/flame-hub/templates/server-telemetry/deployment.yaml
+++ b/charts/flame-hub/templates/server-telemetry/deployment.yaml
@@ -23,7 +23,7 @@ spec:
                     command: [
                         'sh',
                         '-c',
-                        'until nc -z -v -w30 {{ .Release.Name }}-postgresql-primary 5432; do echo "Waiting for db..."; sleep 5; done'
+                        'until nc -z -v -w30 {{ include "flameHub.postgresql.host" . }} 5432; do echo "Waiting for db..."; sleep 5; done'
                     ]
                 -   name: wait-for-redis
                     image: busybox
@@ -81,14 +81,14 @@ spec:
                         -   name: DB_TYPE
                             value: "postgres"
                         -   name: DB_HOST
-                            value: "{{ .Release.Name }}-postgresql-primary"
+                            value: {{ include "flameHub.postgresql.host" . | quote }}
                         -   name: DB_USERNAME
                             value: "postgres"
                         -   name: DB_PASSWORD
                             valueFrom:
                                 secretKeyRef:
-                                    name: {{ include "flameHub.effectiveSecretName" .  }}
-                                    key: postgresql-password
+                                    name: {{ include "flameHub.postgresql.secretName" . }}
+                                    key: password
                         -   name: DB_DATABASE
                             value: "telemetry"
                         -   name: CLIENT_ID

--- a/charts/flame-hub/templates/server-telemetry/deployment.yaml
+++ b/charts/flame-hub/templates/server-telemetry/deployment.yaml
@@ -83,7 +83,10 @@ spec:
                         -   name: DB_HOST
                             value: {{ include "flameHub.postgresql.host" . | quote }}
                         -   name: DB_USERNAME
-                            value: "postgres"
+                            valueFrom:
+                                secretKeyRef:
+                                    name: {{ include "flameHub.postgresql.secretName" . }}
+                                    key: username
                         -   name: DB_PASSWORD
                             valueFrom:
                                 secretKeyRef:

--- a/charts/flame-hub/values.yaml
+++ b/charts/flame-hub/values.yaml
@@ -293,47 +293,51 @@ seaweedfs:
             # See /charts/third-party/openebs for details
             # storageClass: "mayastor-replicated"
 
+# Self-hosted single-node PostgreSQL.
+# Replaces the Bitnami postgresql subchart (whose maintained images now require a paid
+# Bitnami subscription) with a minimal, operator-free StatefulSet on the official
+# PostgreSQL image. It stays release-scoped: the Service is published as
+# "<release>-postgresql-primary" on port 5432 — exactly the host Harbor's
+# externalDatabase, authup and the server-* services already point at — so the chart
+# can still be installed multiple times in one namespace without overriding any
+# connection variables. The password is sourced from the shared credentials secret
+# (auth.secretName / auth.existingSecret, key: postgresql-password).
 postgresql:
-    nameOverride: "postgresql"
     image:
-        repository: "bitnamilegacy/postgresql"
-        tag: "17.6.0-debian-12-r4"
+        repository: "postgres"
+        tag: "17.6"
+        pullPolicy: "IfNotPresent"
     auth:
+        # Superuser the services authenticate as (matches harbor externalDatabase.user
+        # and the server-* DB_USERNAME).
+        username: "postgres"
+        # Optional fixed superuser password. Leave empty to auto-generate; the value is
+        # surfaced through the shared credentials secret under secretPasswordKey.
         postgresPassword: "" # Leave empty for auto-generation
-        replicationPassword: "" # Leave empty for auto-generation
-        existingSecret: "flame-hub-auth"
-        secretKeys:
-            adminPasswordKey: "postgresql-password"
-            replicationPasswordKey: "postgresql-replication-password"
-    primary:
-        startupProbe:
-            failureThreshold: 30
-        readinessProbe:
-            failureThreshold: 20
-        persistence:
-            enabled: true
-            size: 16Gi
-            # See /charts/third-party/openebs for details
-            # storageClass: "mayastor-replicated"
-        extendedConfiguration: |
-            max_connections = 1024
-        # https://github.com/bitnami/charts/blob/main/bitnami/harbor/values.yaml
-        initdb:
-            scripts:
-                initial-registry.sql: |
-                    CREATE DATABASE registry ENCODING 'UTF8';
-                    \c registry;
-                    CREATE TABLE schema_migrations(version bigint not null primary key, dirty boolean not null);
-    readReplicas:
-        replicaCount: 0
-        persistence:
-            enabled: true
-            size: 16Gi
-        startupProbe:
-            failureThreshold: 30
-        readinessProbe:
-            failureThreshold: 20
-    architecture: "replication"
+        # Key in the shared credentials secret that holds the superuser password.
+        secretPasswordKey: "postgresql-password"
+    # Application databases created on first initialisation only (empty data dir).
+    # registry is consumed by Harbor; core/storage/telemetry/auth by the FLAME services.
+    databases:
+        - core
+        - storage
+        - telemetry
+        - auth
+        - registry
+    service:
+        port: 5432
+    persistence:
+        size: 16Gi
+        # See /charts/third-party/openebs for details
+        # storageClass: "mayastor-replicated"
+    # Extra flags passed to the postgres server process (mirrors the previous
+    # max_connections tuning).
+    extraArgs:
+        - "-c"
+        - "max_connections=1024"
+    podSecurityContext:
+        fsGroup: 999
+    resources: {}
 
 grafana:
     nameOverride: "grafana"

--- a/charts/flame-hub/values.yaml
+++ b/charts/flame-hub/values.yaml
@@ -63,9 +63,9 @@ global:
             # Override per-release only for multiple installs in one namespace.
             secretName: "flame-hub-pg"
             # Bring your own Secret instead: set this to its name and the chart will not
-            # create one, it only reads yours (key must be "password"; goharbor hardcodes
-            # it). Everything that reads the Secret — hub workloads and the authup
-            # subchart follow this automatically.
+            # create one, it only reads yours (must contain both "username" and "password"
+            # keys; goharbor hardcodes "password"). Everything that reads the Secret — hub
+            # workloads and the authup subchart follow this automatically.
             # Keep in sync with harbor.externalDatabase.existingSecret
             existingSecret: ""
 

--- a/charts/flame-hub/values.yaml
+++ b/charts/flame-hub/values.yaml
@@ -53,6 +53,22 @@ global:
             nginxGatewayFabric:
                 snippets: false
 
+        # PostgreSQL service and secret, kept under global so subcharts (authup) can read
+        # them: Helm shares only `global` into a subchart's values.
+        postgresql:
+            # Service host. Not release-scoped (goharbor cannot derive the release name).
+            # keep in sync with harbor.externalDatabase.host
+            host: "postgresql"
+            # Name of the chart-managed Secret (created when existingSecret is empty).
+            # Override per-release only for multiple installs in one namespace.
+            secretName: "flame-hub-pg"
+            # Bring your own Secret instead: set this to its name and the chart will not
+            # create one, it only reads yours (key must be "password"; goharbor hardcodes
+            # it). Everything that reads the Secret — hub workloads and the authup
+            # subchart follow this automatically.
+            # Keep in sync with harbor.externalDatabase.existingSecret
+            existingSecret: ""
+
 image:
     registry: ghcr.io
     repository: privateaim/hub
@@ -172,6 +188,11 @@ auth:
 # Authentication Provider
 authup:
     publicHttps: false # global.flameHub.publicHttps also enables this
+    # Rendered via tpl in the authup subchart context, so these follow the global.
+    # no need to edit them alongside the pg values.
+    database:
+        host: '{{ include "flameHub.postgresql.host" . }}'
+        existingSecret: '{{ include "flameHub.postgresql.secretName" . }}'
     # Trusted first-party application origins (redirect allowlist for the web client; not CORS).
     # Accepts a comma-separated string or list; bare hosts expand to both http and https origins.
     # The value is rendered as a Helm template inside the authup subchart context.
@@ -293,29 +314,17 @@ seaweedfs:
             # See /charts/third-party/openebs for details
             # storageClass: "mayastor-replicated"
 
-# Self-hosted single-node PostgreSQL.
-# Replaces the Bitnami postgresql subchart (whose maintained images now require a paid
-# Bitnami subscription) with a minimal, operator-free StatefulSet on the official
-# PostgreSQL image. It stays release-scoped: the Service is published as
-# "<release>-postgresql-primary" on port 5432 — exactly the host Harbor's
-# externalDatabase, authup and the server-* services already point at — so the chart
-# can still be installed multiple times in one namespace without overriding any
-# connection variables. The password is sourced from the shared credentials secret
-# (auth.secretName / auth.existingSecret, key: postgresql-password).
 postgresql:
     image:
         repository: "postgres"
         tag: "17.6"
         pullPolicy: "IfNotPresent"
     auth:
-        # Superuser the services authenticate as (matches harbor externalDatabase.user
-        # and the server-* DB_USERNAME).
+        # Superuser the services authenticate as
         username: "postgres"
-        # Optional fixed superuser password. Leave empty to auto-generate; the value is
-        # surfaced through the shared credentials secret under secretPasswordKey.
         postgresPassword: "" # Leave empty for auto-generation
-        # Key in the shared credentials secret that holds the superuser password.
-        secretPasswordKey: "postgresql-password"
+        # The Secret name and the bring-your-own option live under
+        # global.flameHub.postgresql; only the password override is here.
     # Application databases created on first initialisation only (empty data dir).
     # registry is consumed by Harbor; core/storage/telemetry/auth by the FLAME services.
     databases:
@@ -325,6 +334,7 @@ postgresql:
         - auth
         - registry
     service:
+        # Host and Secret name are under global.flameHub.postgresql. Only the port is here.
         port: 5432
     persistence:
         size: 16Gi
@@ -466,7 +476,7 @@ harbor:
                   [
                       "sh",
                       "-c",
-                      'until nc -z -v -w30 {{ .Release.Name }}-postgresql-primary 5432; do echo "Waiting for db..."; sleep 5; done',
+                      'until nc -z -v -w30 postgresql 5432; do echo "Waiting for db..."; sleep 5; done',
                   ]
     core:
         image:
@@ -480,7 +490,7 @@ harbor:
                   [
                       "sh",
                       "-c",
-                      'until nc -z -v -w30 {{ .Release.Name }}-postgresql-primary 5432; do echo "Waiting for db..."; sleep 5; done',
+                      'until nc -z -v -w30 postgresql 5432; do echo "Waiting for db..."; sleep 5; done',
                   ]
     jobservice:
         updateStrategy:
@@ -497,7 +507,7 @@ harbor:
                   [
                       "sh",
                       "-c",
-                      'until nc -z -v -w30 {{ .Release.Name }}-postgresql-primary 5432; do echo "Waiting for db..."; sleep 5; done',
+                      'until nc -z -v -w30 postgresql 5432; do echo "Waiting for db..."; sleep 5; done',
                   ]
 
     registry:
@@ -522,7 +532,7 @@ harbor:
                   [
                       "sh",
                       "-c",
-                      'until nc -z -v -w30 {{ .Release.Name }}-postgresql-primary 5432; do echo "Waiting for db..."; sleep 5; done',
+                      'until nc -z -v -w30 postgresql 5432; do echo "Waiting for db..."; sleep 5; done',
                   ]
     trivy:
         updateStrategy:
@@ -538,18 +548,18 @@ harbor:
                   [
                       "sh",
                       "-c",
-                      'until nc -z -v -w30 {{ .Release.Name }}-postgresql-primary 5432; do echo "Waiting for db..."; sleep 5; done',
+                      'until nc -z -v -w30 postgresql 5432; do echo "Waiting for db..."; sleep 5; done',
                   ]
     postgresql:
         enabled: false
     externalDatabase:
-        host: "{{ .Release.Name }}-postgresql-primary"
+        host: "postgresql" # Must match global.flameHub.postgresql.host (goharbor cannot template this)
         port: 5432
         user: "postgres"
         password: ""
         coreDatabase: "registry"
-        existingSecret: "flame-hub-auth"
-        existingSecretPasswordKey: "postgresql-password"
+        existingSecret: "flame-hub-pg" # Must match the effective global.flameHub.postgresql secret (existingSecret or secretName)
+        existingSecretPasswordKey: "password"
         sslmode: "disable"
     redis:
         enabled: true

--- a/charts/third-party/authup/templates/deployment.yaml
+++ b/charts/third-party/authup/templates/deployment.yaml
@@ -22,7 +22,7 @@ spec:
               command: [
                   'sh',
                   '-c',
-                  'until nc -z -v -w30 {{ .Release.Name }}-postgresql-primary 5432; do echo "Waiting for db..."; sleep 5; done'
+                  'until nc -z -v -w30 {{ tpl (required "database.host is required (set authup.database.host in the parent chart)" .Values.database.host) $ }} 5432; do echo "Waiting for db..."; sleep 5; done'
               ]
           -   name: wait-for-redis
               image: busybox
@@ -61,11 +61,6 @@ spec:
                     secretKeyRef:
                       name: {{ .Values.auth.existingSecret }}
                       key: redis-connection-string
-              -   name: DB_PASSWORD
-                  valueFrom:
-                    secretKeyRef:
-                      name: {{ .Values.auth.existingSecret }}
-                      key: postgresql-password
               -   name: USER_ADMIN_PASSWORD
                   valueFrom:
                     secretKeyRef:
@@ -81,8 +76,6 @@ spec:
             {{- else }}
               -   name: REDIS
                   value: "redis://default:{{ .Values.auth.redisPassword }}@{{ .Release.Name }}-redis-master:6379"
-              -   name: DB_PASSWORD
-                  value: {{ .Values.auth.postgresPassword | quote }}
               -   name: USER_ADMIN_PASSWORD
                   value: {{ .Values.auth.adminPassword | quote }}
               -   name: CLIENT_SYSTEM_SECRET
@@ -97,11 +90,23 @@ spec:
               -   name: DB_TYPE
                   value: "postgres"
               -   name: DB_HOST
-                  value: "{{ .Release.Name }}-postgresql-primary"
+                  value: {{ tpl (required "database.host is required (set authup.database.host in the parent chart)" .Values.database.host) $ | quote }}
               -   name: DB_USERNAME
                   value: "postgres"
               -   name: DB_DATABASE
                   value: "auth"
+              {{/* Sits outside the auth.existingSecret branch above: the database
+                   credential has its own Secret, independent of the shared auth one. */}}
+              -   name: DB_PASSWORD
+                  {{- $dbSecret := tpl (.Values.database.existingSecret | default "") $ }}
+                  {{- if $dbSecret }}
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ $dbSecret }}
+                      key: {{ .Values.database.passwordKey | quote }}
+                  {{- else }}
+                  value: {{ .Values.auth.postgresPassword | quote }}
+                  {{- end }}
           resources:
               requests:
                   memory: "512Mi"

--- a/charts/third-party/authup/templates/deployment.yaml
+++ b/charts/third-party/authup/templates/deployment.yaml
@@ -92,7 +92,15 @@ spec:
               -   name: DB_HOST
                   value: {{ tpl (required "database.host is required (set authup.database.host in the parent chart)" .Values.database.host) $ | quote }}
               -   name: DB_USERNAME
-                  value: "postgres"
+                  {{- $dbUserSecret := tpl (.Values.database.existingSecret | default "") $ }}
+                  {{- if $dbUserSecret }}
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ $dbUserSecret }}
+                      key: {{ .Values.database.usernameKey | quote }}
+                  {{- else }}
+                  value: {{ .Values.database.username | quote }}
+                  {{- end }}
               -   name: DB_DATABASE
                   value: "auth"
               {{/* Sits outside the auth.existingSecret branch above: the database
@@ -105,7 +113,7 @@ spec:
                       name: {{ $dbSecret }}
                       key: {{ .Values.database.passwordKey | quote }}
                   {{- else }}
-                  value: {{ .Values.auth.postgresPassword | quote }}
+                  value: {{ .Values.database.password | quote }}
                   {{- end }}
           resources:
               requests:

--- a/charts/third-party/authup/values.yaml
+++ b/charts/third-party/authup/values.yaml
@@ -12,7 +12,6 @@ image:
     pullPolicy: "Always"
 
 auth:
-    # Use an existing secret with keys: client-secret, redis-connection-string, postgresql-password
     existingSecret: ""
 
     # or provide credentials in values (used when existingSecret is not set)
@@ -38,6 +37,14 @@ provisioning:
     # Map of filename -> file content, used only when existingConfigMap is empty.
     # Each key becomes a file in the provisioning directory (json/yaml/yml/ts/js).
     files: {}
+
+
+database:
+    host: ""
+    # Secret holding the DB password. When empty, auth.postgresPassword is used inline
+    # instead, which is only appropriate for standalone/dev installs.
+    existingSecret: ""
+    passwordKey: "password"
 
 cookieDomain: ""
 publicURL: ""

--- a/charts/third-party/authup/values.yaml
+++ b/charts/third-party/authup/values.yaml
@@ -16,7 +16,6 @@ auth:
 
     # or provide credentials in values (used when existingSecret is not set)
     redisPassword: "start123"
-    postgresPassword: "start123"
     adminPassword: "start123"
     clientSecret: "start123"
 
@@ -41,10 +40,13 @@ provisioning:
 
 database:
     host: ""
-    # Secret holding the DB password. When empty, auth.postgresPassword is used inline
-    # instead, which is only appropriate for standalone/dev installs.
+    # Secret holding the DB credentials. When empty, the inline username/password
     existingSecret: ""
     passwordKey: "password"
+    usernameKey: "username"
+    # Inline credentials, used only when existingSecret is not set.
+    username: "postgres"
+    password: "start123"
 
 cookieDomain: ""
 publicURL: ""


### PR DESCRIPTION
Unfortunately we need to hardcode the postgres service name and secret name because the future migration to goharbor requires it. Using the global.flameHub values we can still pass the values automatically to authup. The remaining hardcoded places are the postgres section and the harbor section of the flame hub values.
To clarify how to run multiple releases in the same namespace I added a section to the readme.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a chart-managed PostgreSQL deployment with persistent storage, health checks, initialization, and configurable databases.
  * Added support for using an existing PostgreSQL secret and configurable database host and credentials.
  * Improved support for running multiple FLAME Hub releases in the same namespace.

* **Documentation**
  * Updated PostgreSQL secret requirements and installation guidance.
  * Documented retained chart-managed Secrets after uninstall.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->