### PR TITLE
chore: bump hub (v0.13.2) and authup (v1.0.0-beta.59)

### DIFF
--- a/charts/flame-hub/templates/authup/provisioning-configmap.yaml
+++ b/charts/flame-hub/templates/authup/provisioning-configmap.yaml
@@ -115,4 +115,31 @@ data:
             - attributes:
                 name: registry
                 is_confidential: false
+{{- if .Values.authup.provisioning.webClient.enabled }}
+      # The Hub UI logs in through the shared `web` client. authup releases
+      # after v1.0.0-beta.58 no longer provision it as a system client, so it
+      # is declared here for every realm (existing and future) via the
+      # wildcard realm entry. `strategy: merge` re-asserts the chart-derived
+      # redirect allowlist on every boot: the follow-the-config behavior the
+      # system client used to provide. A bare `*` is a YAML alias token, so
+      # the name must stay quoted.
+      - attributes:
+          name: "*"
+        relations:
+          clients:
+            - attributes:
+                name: web
+                displayName: Web
+                authMethod: none
+                grantTypes: authorization_code refresh_token
+                builtIn: true
+                redirectUri: 'http://{{ include "flameHub.uiDomain" . }}/**,https://{{ include "flameHub.uiDomain" . }}/**'
+                postLogoutRedirectUri: 'http://{{ include "flameHub.uiDomain" . }}/**,https://{{ include "flameHub.uiDomain" . }}/**'
+              strategy:
+                type: merge
+              relations:
+                globalScopes:
+                  - global
+                  - openid
+{{- end }}
 {{- end }}

--- a/charts/flame-hub/templates/authup/provisioning-configmap.yaml
+++ b/charts/flame-hub/templates/authup/provisioning-configmap.yaml
@@ -115,31 +115,4 @@ data:
             - attributes:
                 name: registry
                 is_confidential: false
-{{- if .Values.authup.provisioning.webClient.enabled }}
-      # The Hub UI logs in through the shared `web` client. authup releases
-      # after v1.0.0-beta.58 no longer provision it as a system client, so it
-      # is declared here for every realm (existing and future) via the
-      # wildcard realm entry. `strategy: merge` re-asserts the chart-derived
-      # redirect allowlist on every boot: the follow-the-config behavior the
-      # system client used to provide. A bare `*` is a YAML alias token, so
-      # the name must stay quoted.
-      - attributes:
-          name: "*"
-        relations:
-          clients:
-            - attributes:
-                name: web
-                displayName: Web
-                authMethod: none
-                grantTypes: authorization_code refresh_token
-                builtIn: true
-                redirectUri: 'http://{{ include "flameHub.uiDomain" . }}/**,https://{{ include "flameHub.uiDomain" . }}/**'
-                postLogoutRedirectUri: 'http://{{ include "flameHub.uiDomain" . }}/**,https://{{ include "flameHub.uiDomain" . }}/**'
-              strategy:
-                type: merge
-              relations:
-                globalScopes:
-                  - global
-                  - openid
-{{- end }}
 {{- end }}

--- a/charts/flame-hub/values.yaml
+++ b/charts/flame-hub/values.yaml
@@ -72,7 +72,7 @@ global:
 image:
     registry: ghcr.io
     repository: privateaim/hub
-    tag: 0.13.1
+    tag: 0.13.2
     pullPolicy: Always
 
 # internal services
@@ -193,7 +193,9 @@ authup:
     database:
         host: '{{ include "flameHub.postgresql.host" . }}'
         existingSecret: '{{ include "flameHub.postgresql.secretName" . }}'
-    # Trusted first-party application origins (redirect allowlist for the web client; not CORS).
+    # Trusted first-party application origins (redirect allowlist for authup's built-in
+    # system clients; not CORS). The Hub UI logs in through the admin-console client, so
+    # its public origin must be covered here.
     # Accepts a comma-separated string or list; bare hosts expand to both http and https origins.
     # The value is rendered as a Helm template inside the authup subchart context.
     # Defaults to the public domain of the Hub UI (derived from the global ingress/gatewayApi hostname).

--- a/charts/flame-hub/values.yaml
+++ b/charts/flame-hub/values.yaml
@@ -194,6 +194,9 @@ authup:
         host: '{{ include "flameHub.postgresql.host" . }}'
         existingSecret: '{{ include "flameHub.postgresql.secretName" . }}'
     # Trusted first-party application origins (redirect allowlist for the web client; not CORS).
+    # Note: authup releases after v1.0.0-beta.58 stop provisioning the shared `web`
+    # client; this list then feeds only the admin-console / account-console system
+    # clients, and the Hub UI's `web` client is declared via provisioning.webClient below.
     # Accepts a comma-separated string or list; bare hosts expand to both http and https origins.
     # The value is rendered as a Helm template inside the authup subchart context.
     # Defaults to the public domain of the Hub UI (derived from the global ingress/gatewayApi hostname).
@@ -209,6 +212,16 @@ authup:
     provisioning:
         enabled: true
         existingConfigMap: '{{ .Release.Name }}-authup-provisioning'
+        # Provision the shared `web` login client (the client the Hub UI
+        # authenticates with) into every realm via authup's wildcard realm
+        # entry. Required from the first authup release AFTER v1.0.0-beta.58,
+        # which stops auto-provisioning the per-realm `web` system client.
+        # MUST stay disabled while the authup image tag is <= v1.0.0-beta.58:
+        # older releases reject the wildcard syntax at startup (and still
+        # provision `web` themselves). Flip to true together with the next
+        # authup image bump.
+        webClient:
+            enabled: false
     auth:
         existingSecret: "flame-hub-auth"
 

--- a/charts/flame-hub/values.yaml
+++ b/charts/flame-hub/values.yaml
@@ -72,7 +72,7 @@ global:
 image:
     registry: ghcr.io
     repository: privateaim/hub
-    tag: 0.12.7
+    tag: 0.13.0
     pullPolicy: Always
 
 # internal services
@@ -201,7 +201,7 @@ authup:
     trustedOrigins: '{{- if or .Values.global.flameHub.ingress.enabled .Values.global.flameHub.gatewayApi.enabled }}{{ include "flameHub.uiDomain" . }}{{- end }}'
     image:
         repository: "authup/authup"
-        tag: "1.0.0-beta.56"
+        tag: "1.0.0-beta.57"
         pullPolicy: "Always"
     # Declaratively provision the FLAME permission taxonomy and the analyst/diz global
     # roles into authup at boot. The content is rendered by

--- a/charts/flame-hub/values.yaml
+++ b/charts/flame-hub/values.yaml
@@ -72,7 +72,7 @@ global:
 image:
     registry: ghcr.io
     repository: privateaim/hub
-    tag: 0.13.0
+    tag: 0.13.1
     pullPolicy: Always
 
 # internal services
@@ -194,9 +194,6 @@ authup:
         host: '{{ include "flameHub.postgresql.host" . }}'
         existingSecret: '{{ include "flameHub.postgresql.secretName" . }}'
     # Trusted first-party application origins (redirect allowlist for the web client; not CORS).
-    # Note: authup releases after v1.0.0-beta.58 stop provisioning the shared `web`
-    # client; this list then feeds only the admin-console / account-console system
-    # clients, and the Hub UI's `web` client is declared via provisioning.webClient below.
     # Accepts a comma-separated string or list; bare hosts expand to both http and https origins.
     # The value is rendered as a Helm template inside the authup subchart context.
     # Defaults to the public domain of the Hub UI (derived from the global ingress/gatewayApi hostname).
@@ -204,7 +201,7 @@ authup:
     trustedOrigins: '{{- if or .Values.global.flameHub.ingress.enabled .Values.global.flameHub.gatewayApi.enabled }}{{ include "flameHub.uiDomain" . }}{{- end }}'
     image:
         repository: "authup/authup"
-        tag: "1.0.0-beta.57"
+        tag: "1.0.0-beta.59"
         pullPolicy: "Always"
     # Declaratively provision the FLAME permission taxonomy and the analyst/diz global
     # roles into authup at boot. The content is rendered by
@@ -212,16 +209,6 @@ authup:
     provisioning:
         enabled: true
         existingConfigMap: '{{ .Release.Name }}-authup-provisioning'
-        # Provision the shared `web` login client (the client the Hub UI
-        # authenticates with) into every realm via authup's wildcard realm
-        # entry. Required from the first authup release AFTER v1.0.0-beta.58,
-        # which stops auto-provisioning the per-realm `web` system client.
-        # MUST stay disabled while the authup image tag is <= v1.0.0-beta.58:
-        # older releases reject the wildcard syntax at startup (and still
-        # provision `web` themselves). Flip to true together with the next
-        # authup image bump.
-        webClient:
-            enabled: false
     auth:
         existingSecret: "flame-hub-auth"
 

--- a/charts/flame-node/values.yaml
+++ b/charts/flame-node/values.yaml
@@ -632,7 +632,7 @@ messageBroker:
   image:
     repository: ghcr.io/privateaim/node-message-broker
     # Overrides the image tag whose default is the chart appVersion.
-    tag: 0.6.4
+    tag: 0.7.0
     # This sets the pull policy for images.
     pullPolicy: IfNotPresent
 

--- a/charts/third-party/authup/values.yaml
+++ b/charts/third-party/authup/values.yaml
@@ -50,7 +50,8 @@ database:
 
 cookieDomain: ""
 publicURL: ""
-# Trusted first-party application origins (redirect allowlist for the web client; not CORS).
+# Trusted first-party application origins (redirect allowlist for the built-in
+# system clients, e.g. admin-console; not CORS).
 # Accepts a comma-separated string or a list. Each entry is either a bare host[:port]
 # (e.g. "hub.local", which expands to both its http and https origin) or an explicit-scheme
 # origin (e.g. "https://hub.local", which contributes exactly that origin). Only http/https.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added SeaweedFS-based S3 storage support for Hub and Node deployments.
  * Added configurable SeaweedFS admin panel exposure through Gateway API routes.
  * Added Authup provisioning for predefined roles, permissions, and realms.
  * Added PostgreSQL initialization and improved configurable database connectivity.
  * Added message broker actuator endpoint exposure.
* **Bug Fixes**
  * Improved Harbor routing and support for external Harbor deployments.
  * Preserved chart-managed credentials across upgrades and uninstallations.
* **Documentation**
  * Clarified credential management and multi-release configuration requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->