### PR TITLE
Refactor node helm to use default hub auth

### DIFF
--- a/charts/flame-node/templates/_helpers.tpl
+++ b/charts/flame-node/templates/_helpers.tpl
@@ -63,6 +63,13 @@ Return the normalized hostname for all node components. Source of truth: expose.
 
 
 {{/*
+Return the hub IDP issuer URL, combining hub.endpoints.auth with hub.auth.userRealm e.g. "https://auth.privateaim.dev/realms/myRealm"
+*/}}
+{{- define "hub.auth.issuerUrl" -}}
+{{- printf "%s/realms/%s" .Values.hub.endpoints.auth .Values.hub.auth.userRealm -}}
+{{- end -}}
+
+{{/*
 Return the secret containing the hub robot secret
 */}}
 {{- define "hub.secretName" -}}
@@ -262,17 +269,6 @@ Set the API's root path. If expose is configured (not none), defaults to "/api" 
     {{- print "/api" -}}
 {{- else -}}
     {{- print "" -}}
-{{- end -}}
-{{- end -}}
-
-{{/*
-Return the endpoint for user authentication
-*/}}
-{{- define "adapter.userIdp.endpoint" -}}
-{{- if .Values.userIdp.hostname -}}
-    {{- print (include "userIdp.hostname" .) -}}
-{{- else -}}
-    {{- print (include "keycloak.service.endpoint" .) -}}
 {{- end -}}
 {{- end -}}
 

--- a/charts/flame-node/templates/_helpers.tpl
+++ b/charts/flame-node/templates/_helpers.tpl
@@ -66,7 +66,8 @@ Return the normalized hostname for all node components. Source of truth: expose.
 Return the hub IDP issuer URL, combining hub.endpoints.auth with hub.auth.userRealm e.g. "https://auth.privateaim.dev/realms/myRealm"
 */}}
 {{- define "hub.auth.issuerUrl" -}}
-{{- printf "%s/realms/%s" .Values.hub.endpoints.auth .Values.hub.auth.userRealm -}}
+{{- $realm := required "hub.auth.userRealm is required" .Values.hub.auth.userRealm -}}
+{{- printf "%s/realms/%s" (.Values.hub.endpoints.auth | trimSuffix "/") $realm -}}
 {{- end -}}
 
 {{/*

--- a/charts/flame-node/templates/hub-adapter/deployment.yaml
+++ b/charts/flame-node/templates/hub-adapter/deployment.yaml
@@ -137,24 +137,24 @@ spec:
               value: {{ .Values.rbac.stewardRole | default "" | quote }}
             - name: RESEARCHER_ROLE
               value: {{ .Values.rbac.researcherRole | default "" | quote }}
-            - name: POSTGRES_EVENT_USER
+            - name: POSTGRES_USER
               valueFrom:
                 secretKeyRef:
                   name: {{ include "postgresql.user.secretName" . }}
                   key: DB_USER
-            - name: POSTGRES_EVENT_PASSWORD
+            - name: POSTGRES_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ include "postgresql.user.secretName" . }}
                   key: DB_PASSWORD
-            - name: POSTGRES_EVENT_DB
+            - name: POSTGRES_DB
               valueFrom:
                 secretKeyRef:
                   name: {{ include "postgresql.user.secretName" . }}
                   key: DB_DATABASE
-            - name: POSTGRES_EVENT_HOST
+            - name: POSTGRES_HOST
               value: {{ include "postgresql.endpoint" . }}
-            - name: POSTGRES_EVENT_PORT
+            - name: POSTGRES_PORT
               value: {{ .Values.postgresql.service.port | default "5432" | quote }}
             {{- if $hasCerts }}
             - name: EXTRA_CA_CERTS

--- a/charts/flame-node/templates/hub-adapter/deployment.yaml
+++ b/charts/flame-node/templates/hub-adapter/deployment.yaml
@@ -84,7 +84,7 @@ spec:
                   name: {{ .Release.Name }}-keycloak-client-secrets
                   key: hubAdapterClientSecret
             - name: IDP_URL
-              value: {{ include "adapter.userIdp.endpoint" . }}
+              value: {{ include "hub.auth.issuerUrl" . | quote }}
             {{- if .Values.victorialogs.enabled }}
             - name: VICTORIA_LOGS_URL
               value: {{ printf "http://%s-victorialogs-server.%s.svc.cluster.local:9428" .Release.Name .Release.Namespace }}

--- a/charts/flame-node/templates/keycloak/flame-keycloak-realm-configmap.yaml
+++ b/charts/flame-node/templates/keycloak/flame-keycloak-realm-configmap.yaml
@@ -31,29 +31,7 @@ data:
           } ]
         }
       },
-      "users" : [ {{ if (eq .Values.keycloakx.defaultUserEnabled true) }}{
-        "username" : "flameuser",
-        "firstName" : "Johnny",
-        "lastName" : "Storm",
-        "email" : "foo@gmail.com",
-        "emailVerified" : true,
-        "enabled" : true,
-        "totp" : false,
-        "credentials" : [ {
-          "type" : "password",
-          "userLabel" : "My password",
-          "secretData" : "{\"value\":\"PYPGjZXTuiL4qZV5yzDJW3B8H91R4qg6/wqgj4FpZ7o=\",\"salt\":\"Dn8bY/M4KsaNYOBB6Wd0Jw==\",\"additionalParameters\":{}}",
-          "credentialData" : "{\"hashIterations\":5,\"algorithm\":\"argon2\",\"additionalParameters\":{\"hashLength\":[\"32\"],\"memory\":[\"7168\"],\"type\":[\"id\"],\"version\":[\"1.3\"],\"parallelism\":[\"1\"]}}"
-        } ],
-        "disableableCredentialTypes" : [ ],
-        "requiredActions" : [ ],
-        "realmRoles" : [ "default-roles-flame" ],
-        "clientRoles" : {
-          "node-ui" : [ {{ .Values.rbac.adminRole | default "admin" | quote }} ]
-        },
-        "notBefore" : 0,
-        "groups" : [ ]
-      }, {{ end }}{
+      "users" : [ {
         "username" : "service-account-service1",
         "emailVerified" : false,
         "enabled" : true,

--- a/charts/flame-node/templates/ui/deployment.yaml
+++ b/charts/flame-node/templates/ui/deployment.yaml
@@ -82,20 +82,16 @@ spec:
             - name: NUXT_PUBLIC_ORIGIN
               value: {{ printf "%s/flame/api/auth" (include "node.hostname" .) | default "http://localhost:3000/flame/api/auth" }}
             - name: NUXT_PUBLIC_IDP_PROVIDER
-              value: {{ .Values.userIdp.provider | default "keycloak" | quote }}
+              value: hub
             - name: NUXT_PUBLIC_IDP_ISSUER
-              value: {{ include "ui.userIdp.endpoint" . }}
-            {{- if (eq (include "ui.auth.internal" .) "true") }}
-            - name: NUXT_PUBLIC_INTERNAL_KEYCLOAK_URL
-              value: {{ include "keycloak.service.endpoint" . }}
-            {{- end }}
+              value: {{ include "hub.auth.issuerUrl" . | quote }}
             - name: NUXT_IDP_CLIENT_ID
-              value: {{ .Values.ui.idp.clientId | default "node-ui" | quote }}
+              value: {{ required "Hub client ID must be set." .Values.hub.auth.clientId  | quote }}
             - name: NUXT_IDP_CLIENT_SECRET
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "ui.keycloak.secretName" . }}
-                  key: {{ include "ui.keycloak.secretKey" . }}
+                  name: {{ include "hub.secretName" . }}
+                  key: clientSecret
             - name: NUXT_AUTH_SECRET
               valueFrom:
                 secretKeyRef:

--- a/charts/flame-node/values.yaml
+++ b/charts/flame-node/values.yaml
@@ -728,7 +728,7 @@ ui:
   image:
     repository: ghcr.io/privateaim/node-ui
     # Overrides the image tag whose default is the chart appVersion.
-    tag: 0.7.1
+    tag: 0.8.0
     # This sets the pull policy for images.
     pullPolicy: IfNotPresent
 

--- a/charts/flame-node/values.yaml
+++ b/charts/flame-node/values.yaml
@@ -58,20 +58,12 @@ offline: false
 ## @param timezone Set the timezone for all components in the FLAME Node, use "TZ identifier" from https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
 timezone: Europe/Berlin
 
-## @param userIdp The following settings are used to configure a separate IDP for the Node UI other than the default keycloak instance
-userIdp:
-  ## @param userIdp.hostname Hostname for a separate IDP to manage users who can access the FLAME Node UI.
-  ## Leave this blank unless you want to use your own IDP
-  hostname:
-  ## @param userIdp.provider User auth provider. Can be 'keycloak', 'auth0', 'authentik', 'onelogin', 'okta', or 'zitadel'
-  provider: keycloak
-
 ## @param rbac Role Based Access Control settings for authenticated users. Controls feature access in the node UI
 rbac:
   ## @param rbac.roleClaimName A period "." separated list of keys leading to the claim in the OIDC token that contains the user's roles
   ## If left blank, RBAC will be disabled and all authenticated users will have full access.
   ## The default value is for the bundled Keycloak instance
-  roleClaimName: "resource_access.node-ui.roles"
+  roleClaimName: "global_access.roles"
   ## @param rbac.adminRole Role name for users who have full access and control as defined in the IDP
   adminRole: "admin"
   ## @param rbac.stewardRole Role name for users who can only modify data stores as defined in the IDP
@@ -128,7 +120,11 @@ hub:
     storage: https://storage.staging.privateaim.net
   ## Credentials used for retrieving a valid token from the hub using a robot account
   auth:
+    ## @param hub.auth.userRealm Realm in which the users for this node are registered
+    userRealm:
+    ## @param hub.auth.clientId Client ID for the node hub client
     clientId:
+    ## @param hub.auth.clientSecret Client secret for the node hub client
     clientSecret:
     ## @param hub.auth.existingSecret Existing k8s secret containing secret for given hub client ID
     ## The secret must have a key named "clientSecret"

--- a/charts/flame-node/values.yaml
+++ b/charts/flame-node/values.yaml
@@ -510,8 +510,7 @@ podOrchestrator:
   image:
     repository: ghcr.io/privateaim/node-pod-orchestration
     # Overrides the image tag whose default is the chart appVersion.
-    # TODO: update to new version once available after testing
-    tag: 0.6.0
+    tag: 0.6.1
     # This sets the pull policy for images.
     pullPolicy: IfNotPresent
 

--- a/charts/flame-node/values.yaml
+++ b/charts/flame-node/values.yaml
@@ -301,9 +301,6 @@ storageService:
 
 # keycloakx values
 keycloakx:
-  ## @param keycloakx.defaultUserEnabled Enable the creation of the default "flameuser" in keycloak
-  defaultUserEnabled: false
-
   auth:
     ## @param keycloakx.auth.adminUsername Bootstrap admin username for Keycloak. Ignored when existingSecret is set.
     adminUsername: ""

--- a/charts/flame-node/values.yaml
+++ b/charts/flame-node/values.yaml
@@ -121,14 +121,14 @@ hub:
   ## Credentials used for retrieving a valid token from the hub using a robot account
   auth:
     ## @param hub.auth.userRealm Realm in which the users for this node are registered
-    userRealm:
+    userRealm: "master"
     ## @param hub.auth.clientId Client ID for the node hub client
     clientId:
     ## @param hub.auth.clientSecret Client secret for the node hub client
     clientSecret:
     ## @param hub.auth.existingSecret Existing k8s secret containing secret for given hub client ID
     ## The secret must have a key named "clientSecret"
-    existingSecret: ""
+    existingSecret:
   ## Values required by the storage service for encrypting intermediate results sent to the Hub
   crypto:
     ## @param hub.crypto.privateKey Content of the private key to be added to the secret. Need to use the "|" scalar:

--- a/charts/flame-node/values.yaml
+++ b/charts/flame-node/values.yaml
@@ -404,7 +404,7 @@ hubAdapter:
   image:
     repository: ghcr.io/privateaim/node-hub-api-adapter
     # Overrides the image tag whose default is the chart appVersion.
-    tag: 0.7.0
+    tag: 0.8.0
     # This sets the pull policy for images.
     pullPolicy: IfNotPresent
 

--- a/charts/flame-node/values_min.yaml
+++ b/charts/flame-node/values_min.yaml
@@ -9,6 +9,7 @@ expose:
 hub:
   ## Credentials used for retrieving a valid token from the hub using a robot account
   auth:
+    userRealm:
     clientId:
     clientSecret:
   ## Values required by the storage service for encrypting intermediate results sent to the Hub
@@ -34,15 +35,11 @@ keycloakx:
     adminPassword: ""
     # existingSecret: ""
 
-# userIdp:
-#   hostname:
-#   provider: keycloak
-
-proxy:
-  httpProxy:
-  httpsProxy:
-  noProxy:
-  # existingSecret:
+# proxy:
+#   httpProxy:
+#   httpsProxy:
+#   noProxy:
+#   existingSecret:
 
 ## If enabled, this will deploy a FHIR and SeaweedFS (S3) server that can be used for testing
 dataStore:
@@ -53,16 +50,3 @@ dataStore:
         adminUser: "admin"
         adminPassword: ""
         # existingSecret: ""
-
-## @param rbac Role Based Access Control settings for authenticated users. Controls feature access in the node UI
-rbac:
-  ## @param rbac.roleClaimName A period "." separated list of keys leading to the claim in the OIDC token that contains the user's roles
-  ## If left blank, RBAC will be disabled and all authenticated users will have full access.
-  ## The default value is for the bundled Keycloak instance
-  roleClaimName: "resource_access.node-ui.roles"
-  ## @param rbac.adminRole Role name for users who have full access and control as defined in the IDP
-  adminRole: "admin"
-  ## @param rbac.stewardRole Role name for users who can only modify data stores as defined in the IDP
-  stewardRole: "steward"
-  ## @param rbac.researcherRole Role name for users who can only modify analyses as defined in the IDP
-  researcherRole: "researcher"

--- a/charts/flame-node/values_min.yaml
+++ b/charts/flame-node/values_min.yaml
@@ -9,7 +9,7 @@ expose:
 hub:
   ## Credentials used for retrieving a valid token from the hub using a robot account
   auth:
-    userRealm:
+    userRealm: master  # change this to the realm in which the users for this node are registered
     clientId:
     clientSecret:
   ## Values required by the storage service for encrypting intermediate results sent to the Hub


### PR DESCRIPTION
Remove options for setting your own IDP for the flame-node helm chart and configure all default settings to point to the hub for authn