### PR TITLE
feat(hub): replace redis subchart with self-managed Redis

### DIFF
--- a/charts/flame-hub/Chart.yaml
+++ b/charts/flame-hub/Chart.yaml
@@ -8,9 +8,6 @@ dependencies:
   - name: common
     version: 2.31.4
     repository: oci://registry-1.docker.io/bitnamicharts
-  - name: redis
-    version: 22.0.6
-    repository: oci://registry-1.docker.io/bitnamicharts
   - name: rabbitmq
     version: 16.0.14
     repository: oci://registry-1.docker.io/bitnamicharts

--- a/charts/flame-hub/README.md
+++ b/charts/flame-hub/README.md
@@ -76,7 +76,6 @@ You must give each release its own value for:
 | `auth.secretName` | `flame-hub-auth` | central chart secret for other service credentials |
 | `authup.auth.existingSecret` | `flame-hub-auth` | subchart reference — **must match** `auth.secretName` |
 | `rabbitmq.auth.existingPasswordSecret` | `flame-hub-auth` | subchart reference — **must match** `auth.secretName` |
-| `redis.auth.existingSecret` | `flame-hub-auth` | subchart reference — **must match** `auth.secretName` |
 | `grafana.admin.existingSecret` | `flame-hub-auth` | subchart reference — **must match** `auth.secretName` |
 | `harbor.secretName` | `flame-hub-harbor` | Harbor's own credentials Secret (admin password, core `secretKey`, connection string) |
 | `harbor.existingSecretAdminPassword` | `flame-hub-harbor` | goharbor reference — **must match** the effective Harbor secret (`harbor.existingSecret` when set, otherwise `harbor.secretName`) |

--- a/charts/flame-hub/templates/_helpers.tpl
+++ b/charts/flame-hub/templates/_helpers.tpl
@@ -86,14 +86,17 @@ Create the name of the service account to use
 
 
 {{/*
-Host of the chart-managed Redis. Read from global.flameHub.redis so the value also
-resolves inside subcharts (Helm shares only `global`); the authup subchart reaches it
-through this helper. Release-scoped by default so multiple flame-hub instances can share
-a namespace; set global.flameHub.redis.host to point every consumer at an external Redis.
+Name/host of the chart-managed Redis Service. Read from global.flameHub.redis so the value also resolves inside
+subcharts (Helm shares only `global`); the authup subchart reaches it through this helper.
 */}}
 {{- define "flameHub.redis.host" -}}
 {{- $redis := (((.Values.global).flameHub).redis) | default dict -}}
 {{- $redis.host | default (printf "%s-redis" .Release.Name) -}}
+{{- end -}}
+
+{{- define "flameHub.redis.port" -}}
+{{- $redis := (((.Values.global).flameHub).redis) | default dict -}}
+{{- $redis.port | default 6379 -}}
 {{- end -}}
 
 

--- a/charts/flame-hub/templates/_helpers.tpl
+++ b/charts/flame-hub/templates/_helpers.tpl
@@ -85,6 +85,18 @@ Create the name of the service account to use
 {{- end -}}
 
 
+{{/*
+Host of the chart-managed Redis. Read from global.flameHub.redis so the value also
+resolves inside subcharts (Helm shares only `global`); the authup subchart reaches it
+through this helper. Release-scoped by default so multiple flame-hub instances can share
+a namespace; set global.flameHub.redis.host to point every consumer at an external Redis.
+*/}}
+{{- define "flameHub.redis.host" -}}
+{{- $redis := (((.Values.global).flameHub).redis) | default dict -}}
+{{- $redis.host | default (printf "%s-redis" .Release.Name) -}}
+{{- end -}}
+
+
 {{- define "flameHub.harbor.secretName" -}}
 {{- .Values.harbor.existingSecret | default (required "harbor.secretName is required" .Values.harbor.secretName) -}}
 {{- end -}}

--- a/charts/flame-hub/templates/credentials-secret.yaml
+++ b/charts/flame-hub/templates/credentials-secret.yaml
@@ -56,7 +56,7 @@ stringData:
   authup-client-secret: {{ $authupClientSecret | quote }}
 
   # Connection strings (pre-built with passwords)
-  redis-connection-string: {{ printf "redis://default:%s@%s:%v" ($redisPassword | urlquery) (include "flameHub.redis.host" .) .Values.redis.service.port | quote }}
+  redis-connection-string: {{ printf "redis://default:%s@%s:%v" ($redisPassword | urlquery) (include "flameHub.redis.host" .) (include "flameHub.redis.port" .) | quote }}
   rabbitmq-connection-string: {{ printf "amqp://%s:%s@%s-rabbitmq:5672" (.Values.rabbitmq.auth.username | urlquery) ($rabbitmqPassword | urlquery) .Release.Name | quote }}
 
 {{- end }}

--- a/charts/flame-hub/templates/credentials-secret.yaml
+++ b/charts/flame-hub/templates/credentials-secret.yaml
@@ -56,7 +56,7 @@ stringData:
   authup-client-secret: {{ $authupClientSecret | quote }}
 
   # Connection strings (pre-built with passwords)
-  redis-connection-string: {{ printf "redis://default:%s@%s-redis-master:6379" ($redisPassword | urlquery) .Release.Name | quote }}
+  redis-connection-string: {{ printf "redis://default:%s@%s:%v" ($redisPassword | urlquery) (include "flameHub.redis.host" .) .Values.redis.service.port | quote }}
   rabbitmq-connection-string: {{ printf "amqp://%s:%s@%s-rabbitmq:5672" (.Values.rabbitmq.auth.username | urlquery) ($rabbitmqPassword | urlquery) .Release.Name | quote }}
 
 {{- end }}

--- a/charts/flame-hub/templates/redis/service.yaml
+++ b/charts/flame-hub/templates/redis/service.yaml
@@ -11,5 +11,5 @@ spec:
     ports:
         -   name: redis
             protocol: TCP
-            port: {{ .Values.redis.service.port }}
+            port: {{ include "flameHub.redis.port" . }}
             targetPort: redis

--- a/charts/flame-hub/templates/redis/service.yaml
+++ b/charts/flame-hub/templates/redis/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+    name: {{ include "flameHub.redis.host" . | quote }}
+    labels:
+        app: "{{ .Release.Name }}-redis"
+spec:
+    clusterIP: None
+    selector:
+        app: "{{ .Release.Name }}-redis"
+    ports:
+        -   name: redis
+            protocol: TCP
+            port: {{ .Values.redis.service.port }}
+            targetPort: redis

--- a/charts/flame-hub/templates/redis/statefulset.yaml
+++ b/charts/flame-hub/templates/redis/statefulset.yaml
@@ -1,0 +1,84 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+    name: "{{ .Release.Name }}-redis"
+    labels:
+        app: "{{ .Release.Name }}-redis"
+spec:
+    serviceName: {{ include "flameHub.redis.host" . | quote }}
+    replicas: 1
+    selector:
+        matchLabels:
+            app: "{{ .Release.Name }}-redis"
+    template:
+        metadata:
+            labels:
+                app: "{{ .Release.Name }}-redis"
+        spec:
+            {{- with .Values.redis.podSecurityContext }}
+            securityContext: {{- toYaml . | nindent 16 }}
+            {{- end }}
+            containers:
+                -   name: redis
+                    image: "{{ .Values.redis.image.repository }}:{{ .Values.redis.image.tag }}"
+                    imagePullPolicy: {{ .Values.redis.image.pullPolicy }}
+                    command:
+                        - "redis-server"
+                        - "--requirepass"
+                        - "$(REDIS_PASSWORD)"
+                        {{- with .Values.redis.extraArgs }}
+                        {{- toYaml . | nindent 24 }}
+                        {{- end }}
+                    env:
+                        -   name: REDIS_PASSWORD
+                            valueFrom:
+                                secretKeyRef:
+                                    name: {{ include "flameHub.effectiveSecretName" . }}
+                                    key: redis-password
+                        # redis-cli picks this up automatically, so the probes need no -a flag.
+                        -   name: REDISCLI_AUTH
+                            valueFrom:
+                                secretKeyRef:
+                                    name: {{ include "flameHub.effectiveSecretName" . }}
+                                    key: redis-password
+                    ports:
+                        -   name: redis
+                            containerPort: 6379
+                    readinessProbe:
+                        exec:
+                            command: ["redis-cli", "ping"]
+                        initialDelaySeconds: 5
+                        periodSeconds: 10
+                        timeoutSeconds: 5
+                        failureThreshold: 20
+                    livenessProbe:
+                        exec:
+                            command: ["redis-cli", "ping"]
+                        initialDelaySeconds: 15
+                        periodSeconds: 10
+                        timeoutSeconds: 5
+                        failureThreshold: 6
+                    {{- with .Values.redis.resources }}
+                    resources: {{- toYaml . | nindent 24 }}
+                    {{- end }}
+                    volumeMounts:
+                        -   name: data
+                            mountPath: /data
+            {{- if not .Values.redis.persistence.enabled }}
+            volumes:
+                -   name: data
+                    emptyDir: {}
+            {{- end }}
+    {{- if .Values.redis.persistence.enabled }}
+    volumeClaimTemplates:
+        -   metadata:
+                name: data
+            spec:
+                accessModes: ["ReadWriteOnce"]
+                {{- with .Values.redis.persistence.storageClass }}
+                storageClassName: {{ . | quote }}
+                {{- end }}
+                resources:
+                    requests:
+                        storage: {{ .Values.redis.persistence.size }}
+    {{- end }}

--- a/charts/flame-hub/templates/server-core/deployment.yaml
+++ b/charts/flame-hub/templates/server-core/deployment.yaml
@@ -37,7 +37,7 @@ spec:
               command: [
                   'sh',
                   '-c',
-                  'until nc -z -v -w30 {{ include "flameHub.redis.host" . }} {{ .Values.redis.service.port }}; do echo "Waiting for redis..."; sleep 5; done'
+                  'until nc -z -v -w30 {{ include "flameHub.redis.host" . }} {{ include "flameHub.redis.port" . }}; do echo "Waiting for redis..."; sleep 5; done'
               ]
           -   name: wait-for-rabbitmq
               image: busybox

--- a/charts/flame-hub/templates/server-core/deployment.yaml
+++ b/charts/flame-hub/templates/server-core/deployment.yaml
@@ -37,7 +37,7 @@ spec:
               command: [
                   'sh',
                   '-c',
-                  'until nc -z -v -w30 {{ .Release.Name }}-redis-master 6379; do echo "Waiting for redis..."; sleep 5; done'
+                  'until nc -z -v -w30 {{ include "flameHub.redis.host" . }} {{ .Values.redis.service.port }}; do echo "Waiting for redis..."; sleep 5; done'
               ]
           -   name: wait-for-rabbitmq
               image: busybox

--- a/charts/flame-hub/templates/server-messenger/deployment.yaml
+++ b/charts/flame-hub/templates/server-messenger/deployment.yaml
@@ -30,7 +30,7 @@ spec:
                     command: [
                         'sh',
                         '-c',
-                        'until nc -z -v -w30 {{ .Release.Name }}-redis-master 6379; do echo "Waiting for redis..."; sleep 5; done'
+                        'until nc -z -v -w30 {{ include "flameHub.redis.host" . }} {{ .Values.redis.service.port }}; do echo "Waiting for redis..."; sleep 5; done'
                     ]
                 -   name: wait-for-rabbitmq
                     image: busybox

--- a/charts/flame-hub/templates/server-messenger/deployment.yaml
+++ b/charts/flame-hub/templates/server-messenger/deployment.yaml
@@ -30,7 +30,7 @@ spec:
                     command: [
                         'sh',
                         '-c',
-                        'until nc -z -v -w30 {{ include "flameHub.redis.host" . }} {{ .Values.redis.service.port }}; do echo "Waiting for redis..."; sleep 5; done'
+                        'until nc -z -v -w30 {{ include "flameHub.redis.host" . }} {{ include "flameHub.redis.port" . }}; do echo "Waiting for redis..."; sleep 5; done'
                     ]
                 -   name: wait-for-rabbitmq
                     image: busybox

--- a/charts/flame-hub/templates/server-storage/deployment.yaml
+++ b/charts/flame-hub/templates/server-storage/deployment.yaml
@@ -30,7 +30,7 @@ spec:
                     command: [
                         'sh',
                         '-c',
-                        'until nc -z -v -w30 {{ .Release.Name }}-redis-master 6379; do echo "Waiting for redis..."; sleep 5; done'
+                        'until nc -z -v -w30 {{ include "flameHub.redis.host" . }} {{ .Values.redis.service.port }}; do echo "Waiting for redis..."; sleep 5; done'
                     ]
                 -   name: wait-for-rabbitmq
                     image: busybox

--- a/charts/flame-hub/templates/server-storage/deployment.yaml
+++ b/charts/flame-hub/templates/server-storage/deployment.yaml
@@ -30,7 +30,7 @@ spec:
                     command: [
                         'sh',
                         '-c',
-                        'until nc -z -v -w30 {{ include "flameHub.redis.host" . }} {{ .Values.redis.service.port }}; do echo "Waiting for redis..."; sleep 5; done'
+                        'until nc -z -v -w30 {{ include "flameHub.redis.host" . }} {{ include "flameHub.redis.port" . }}; do echo "Waiting for redis..."; sleep 5; done'
                     ]
                 -   name: wait-for-rabbitmq
                     image: busybox

--- a/charts/flame-hub/templates/server-telemetry/deployment.yaml
+++ b/charts/flame-hub/templates/server-telemetry/deployment.yaml
@@ -30,7 +30,7 @@ spec:
                     command: [
                         'sh',
                         '-c',
-                        'until nc -z -v -w30 {{ .Release.Name }}-redis-master 6379; do echo "Waiting for redis..."; sleep 5; done'
+                        'until nc -z -v -w30 {{ include "flameHub.redis.host" . }} {{ .Values.redis.service.port }}; do echo "Waiting for redis..."; sleep 5; done'
                     ]
                 -   name: wait-for-rabbitmq
                     image: busybox

--- a/charts/flame-hub/templates/server-telemetry/deployment.yaml
+++ b/charts/flame-hub/templates/server-telemetry/deployment.yaml
@@ -30,7 +30,7 @@ spec:
                     command: [
                         'sh',
                         '-c',
-                        'until nc -z -v -w30 {{ include "flameHub.redis.host" . }} {{ .Values.redis.service.port }}; do echo "Waiting for redis..."; sleep 5; done'
+                        'until nc -z -v -w30 {{ include "flameHub.redis.host" . }} {{ include "flameHub.redis.port" . }}; do echo "Waiting for redis..."; sleep 5; done'
                     ]
                 -   name: wait-for-rabbitmq
                     image: busybox

--- a/charts/flame-hub/values.yaml
+++ b/charts/flame-hub/values.yaml
@@ -69,12 +69,12 @@ global:
             # Keep in sync with harbor.database.external.existingSecret
             existingSecret: ""
 
-        # Redis service host, kept under global so the authup subchart can read it
-        # (Helm shares only `global`). Consumed via the flameHub.redis.host helper.
+        # Consumed via the flameHub.redis.host / flameHub.redis.port helpers, which also name the chart-managed Redis Service.
         redis:
-            # Leave empty for the release-scoped default "<release>-redis" (the
-            # chart-managed Redis in templates/redis).
+            # Name of the chart-managed Redis Service. Leave empty for the release-scoped
+            # default "<release>-redis". This is NOT an external-Redis switch.
             host: ""
+            port: 6379
 
 image:
     registry: ghcr.io
@@ -200,9 +200,10 @@ authup:
     database:
         host: '{{ include "flameHub.postgresql.host" . }}'
         existingSecret: '{{ include "flameHub.postgresql.secretName" . }}'
-    # Redis host for authup, following the chart-managed Redis (or redis.host override).
+    # Redis host/port for authup, following the chart-managed Redis (global.flameHub.redis).
     redis:
         host: '{{ include "flameHub.redis.host" . }}'
+        port: '{{ include "flameHub.redis.port" . }}'
     # Trusted first-party application origins (redirect allowlist for authup's built-in
     # system clients; not CORS). The Hub UI logs in through the admin-console client, so
     # its public origin must be covered here.
@@ -260,8 +261,8 @@ rabbitmq:
 # The password lives in the shared flame-hub-auth Secret under
 # redis-password/redis-connection-string.
 redis:
-    # Service host is configured under global.flameHub.redis.host (needs to be readable
-    # by the authup subchart).
+    # Service host/port are configured under global.flameHub.redis (they must be readable
+    # by the authup subchart). The settings below configure the chart-managed Redis pod.
     image:
         repository: "redis"
         tag: "8.2.1"
@@ -270,8 +271,6 @@ redis:
         # Password override; leave empty for auto-generation into flame-hub-auth.
         # The Secret name / bring-your-own option is auth.secretName / auth.existingSecret.
         password: ""
-    service:
-        port: 6379
     persistence:
         enabled: true
         size: 4Gi

--- a/charts/flame-hub/values.yaml
+++ b/charts/flame-hub/values.yaml
@@ -69,6 +69,13 @@ global:
             # Keep in sync with harbor.database.external.existingSecret
             existingSecret: ""
 
+        # Redis service host, kept under global so the authup subchart can read it
+        # (Helm shares only `global`). Consumed via the flameHub.redis.host helper.
+        redis:
+            # Leave empty for the release-scoped default "<release>-redis" (the
+            # chart-managed Redis in templates/redis).
+            host: ""
+
 image:
     registry: ghcr.io
     repository: privateaim/hub
@@ -193,6 +200,9 @@ authup:
     database:
         host: '{{ include "flameHub.postgresql.host" . }}'
         existingSecret: '{{ include "flameHub.postgresql.secretName" . }}'
+    # Redis host for authup, following the chart-managed Redis (or redis.host override).
+    redis:
+        host: '{{ include "flameHub.redis.host" . }}'
     # Trusted first-party application origins (redirect allowlist for authup's built-in
     # system clients; not CORS). The Hub UI logs in through the admin-console client, so
     # its public origin must be covered here.
@@ -246,25 +256,32 @@ rabbitmq:
     # See /charts/third-party/openebs for details
     # persistence:
     #     storageClass: "mayastor-replicated"
+# Single-node Redis (no replication). Rendered from templates/redis.
+# The password lives in the shared flame-hub-auth Secret under
+# redis-password/redis-connection-string.
 redis:
-    nameOverride: "redis"
-    startupProbe:
-        failureThreshold: 15
-    readinessProbe:
-        failureThreshold: 10
-    auth:
-        enabled: true
-        password: "" # Leave empty for auto-generation
-        existingSecret: "flame-hub-auth"
-        existingSecretPasswordKey: "redis-password"
+    # Service host is configured under global.flameHub.redis.host (needs to be readable
+    # by the authup subchart).
     image:
-        #repository: "tada5hi/redis"
-        repository: "bitnamilegacy/redis"
-        tag: "8.2.1-debian-12-r0"
-    # See /charts/third-party/openebs for details
-    # master:
-    #     persistence:
-    #         storageClass: "mayastor-replicated"
+        repository: "redis"
+        tag: "8.2.1"
+        pullPolicy: "IfNotPresent"
+    auth:
+        # Password override; leave empty for auto-generation into flame-hub-auth.
+        # The Secret name / bring-your-own option is auth.secretName / auth.existingSecret.
+        password: ""
+    service:
+        port: 6379
+    persistence:
+        enabled: true
+        size: 4Gi
+        # See /charts/third-party/openebs for details
+        # storageClass: "mayastor-replicated"
+    # Extra flags appended to the redis-server command (after --requirepass).
+    extraArgs: []
+    podSecurityContext:
+        fsGroup: 999
+    resources: {}
 
 # seaweedfs is the S3 object store used by server-storage.
 # S3 admin credentials are auto-generated into the "<release>-seaweedfs-s3-secret" Secret

--- a/charts/third-party/authup/templates/deployment.yaml
+++ b/charts/third-party/authup/templates/deployment.yaml
@@ -29,7 +29,7 @@ spec:
               command: [
                   'sh',
                   '-c',
-                  'until nc -z -v -w30 {{ tpl (.Values.redis.host | default (printf "%s-redis" .Release.Name)) $ }} 6379; do echo "Waiting for redis..."; sleep 5; done'
+                  'until nc -z -v -w30 {{ tpl (.Values.redis.host | default (printf "%s-redis" .Release.Name)) $ }} {{ tpl (.Values.redis.port | toString | default "6379") $ }}; do echo "Waiting for redis..."; sleep 5; done'
               ]
       containers:
         - name: "{{ .Release.Name }}-authup-server-core"
@@ -75,7 +75,7 @@ spec:
                       key: authup-client-secret
             {{- else }}
               -   name: REDIS
-                  value: "redis://default:{{ .Values.auth.redisPassword }}@{{ tpl (.Values.redis.host | default (printf "%s-redis" .Release.Name)) $ }}:6379"
+                  value: "redis://default:{{ .Values.auth.redisPassword }}@{{ tpl (.Values.redis.host | default (printf "%s-redis" .Release.Name)) $ }}:{{ tpl (.Values.redis.port | toString | default "6379") $ }}"
               -   name: USER_ADMIN_PASSWORD
                   value: {{ .Values.auth.adminPassword | quote }}
               -   name: CLIENT_SYSTEM_SECRET

--- a/charts/third-party/authup/templates/deployment.yaml
+++ b/charts/third-party/authup/templates/deployment.yaml
@@ -29,7 +29,7 @@ spec:
               command: [
                   'sh',
                   '-c',
-                  'until nc -z -v -w30 {{ .Release.Name }}-redis-master 6379; do echo "Waiting for redis..."; sleep 5; done'
+                  'until nc -z -v -w30 {{ tpl (.Values.redis.host | default (printf "%s-redis" .Release.Name)) $ }} 6379; do echo "Waiting for redis..."; sleep 5; done'
               ]
       containers:
         - name: "{{ .Release.Name }}-authup-server-core"
@@ -75,7 +75,7 @@ spec:
                       key: authup-client-secret
             {{- else }}
               -   name: REDIS
-                  value: "redis://default:{{ .Values.auth.redisPassword }}@{{ .Release.Name }}-redis-master:6379"
+                  value: "redis://default:{{ .Values.auth.redisPassword }}@{{ tpl (.Values.redis.host | default (printf "%s-redis" .Release.Name)) $ }}:6379"
               -   name: USER_ADMIN_PASSWORD
                   value: {{ .Values.auth.adminPassword | quote }}
               -   name: CLIENT_SYSTEM_SECRET

--- a/charts/third-party/authup/values.yaml
+++ b/charts/third-party/authup/values.yaml
@@ -42,6 +42,8 @@ redis:
     # Redis host authup connects to. Rendered with tpl, so a parent chart may pass a
     # helper, e.g. '{{ include "flameHub.redis.host" . }}'. Defaults to <release>-redis.
     host: ""
+    # Redis port. Also tpl-rendered (a parent may pass a helper). Defaults to 6379.
+    port: ""
 
 database:
     host: ""

--- a/charts/third-party/authup/values.yaml
+++ b/charts/third-party/authup/values.yaml
@@ -38,6 +38,11 @@ provisioning:
     files: {}
 
 
+redis:
+    # Redis host authup connects to. Rendered with tpl, so a parent chart may pass a
+    # helper, e.g. '{{ include "flameHub.redis.host" . }}'. Defaults to <release>-redis.
+    host: ""
+
 database:
     host: ""
     # Secret holding the DB credentials. When empty, the inline username/password


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configurable, self-managed Redis deployment with optional persistent storage and custom service ports.
  * Added support for shared Redis host configuration across platform components.
  * Hub Adapter now receives message broker, S3, and FHIR connection settings when applicable.
  * Added support for SeaweedFS name overrides and updated storage configuration options.

* **Bug Fixes**
  * Added validation for Harbor settings and SeaweedFS URL prefixes.
  * Improved Redis connectivity configuration and service discovery.

* **Chores**
  * Updated platform component image versions.
  * Renamed the Hub client secret to use clearer terminology.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->